### PR TITLE
defaults 'get' now falls back to initial defaults

### DIFF
--- a/MorphicService/MorphicService/Session.swift
+++ b/MorphicService/MorphicService/Session.swift
@@ -463,6 +463,9 @@ public class Session{
         }
     }
     
+    /// The initial default preferences
+    public static var initialPreferences: Preferences?
+    
     /// The current user's preferences
     public var preferences: Preferences?
     
@@ -476,27 +479,27 @@ public class Session{
     }
     
     public func string(for key: Preferences.Key) -> String?{
-        return preferences?.get(key: key) as? String
+        return (preferences?.get(key: key) ?? Session.initialPreferences?.get(key: key)) as? String
     }
     
     public func int(for key: Preferences.Key) -> Int?{
-        return preferences?.get(key: key) as? Int
+        return (preferences?.get(key: key) ?? Session.initialPreferences?.get(key: key)) as? Int
     }
     
     public func double(for key: Preferences.Key) -> Double?{
-        return preferences?.get(key: key) as? Double
+        return (preferences?.get(key: key) ?? Session.initialPreferences?.get(key: key)) as? Double
     }
     
     public func bool(for key: Preferences.Key) -> Bool?{
-        return preferences?.get(key: key) as? Bool
+        return (preferences?.get(key: key) ?? Session.initialPreferences?.get(key: key)) as? Bool
     }
     
     public func array(for key: Preferences.Key) -> [Interoperable?]?{
-        return preferences?.get(key: key) as? [Interoperable?]
+        return (preferences?.get(key: key) ?? Session.initialPreferences?.get(key: key)) as? [Interoperable?]
     }
     
     public func dictionary(for key: Preferences.Key) -> [String: Interoperable?]?{
-        return preferences?.get(key: key) as? [String: Interoperable?]
+        return (preferences?.get(key: key) ?? Session.initialPreferences?.get(key: key)) as? [String: Interoperable?]
     }
     
     public func applyAllPreferences(completion: @escaping () -> Void){


### PR DESCRIPTION
Previously, Morphic read in the Initial Default Preferences file once and wrote it out to the "__default__.json" preferences file.

But when new versions of Morphic are released with new entries in the Initial Default Preferences file, Morphic was just seeing nil values in the system's "__defaults__" preferences file (and would not see new defaults entries shipped with new versions of Morphic).

This fix makes three precise changes:
1. When Morphic starts up, it always loads the initial default preferences into a static "initial preferences" variable; previously it instead copied the initial preferences into "__default__.json" if "__default.json__" didn't yet exist.
2. Instead of saving the initial default preferences into "__default.json__", Morphic creates an empty one if one doesn't already exist (so that new/overriding preferences can be saved there).  
3. When reading values from the session's current preferences file, if a preference/setting is missing...the session now also checks the Initial Default Preferences for a backup/default value.

The above should result in new settings being captured for users and testers post-upgrade.  [Some beta users already had issues loading Morphic after required default-settings-names were changed; this should fix that issue for some of those users as well.]

All of the above should also work with the {userid}.json scheme.