### PR TITLE
add automatic accessibility authorization popups

### DIFF
--- a/MorphicSettings/MorphicSettings.xcodeproj/project.pbxproj
+++ b/MorphicSettings/MorphicSettings.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		9D0AF73724A0FB67007E177E /* MorphicA11yUIAttributeValueCompatible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D0AF73624A0FB67007E177E /* MorphicA11yUIAttributeValueCompatible.swift */; };
 		9D0AF73924A0FB78007E177E /* MorphicA11yUIElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D0AF73824A0FB78007E177E /* MorphicA11yUIElement.swift */; };
 		9D5EC22C24927EFD00AC77B5 /* MorphicPropertyList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D5EC22B24927EFD00AC77B5 /* MorphicPropertyList.swift */; };
+		9DCE209224CF1AAF00D3445B /* MorphicA11yAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCE209124CF1AAF00D3445B /* MorphicA11yAuthorization.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -142,6 +143,7 @@
 		9D0AF73624A0FB67007E177E /* MorphicA11yUIAttributeValueCompatible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MorphicA11yUIAttributeValueCompatible.swift; sourceTree = "<group>"; };
 		9D0AF73824A0FB78007E177E /* MorphicA11yUIElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MorphicA11yUIElement.swift; sourceTree = "<group>"; };
 		9D5EC22B24927EFD00AC77B5 /* MorphicPropertyList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MorphicPropertyList.swift; sourceTree = "<group>"; };
+		9DCE209124CF1AAF00D3445B /* MorphicA11yAuthorization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MorphicA11yAuthorization.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -354,6 +356,7 @@
 		9D0AF73524A0FB49007E177E /* AccessibilityUI */ = {
 			isa = PBXGroup;
 			children = (
+				9DCE209124CF1AAF00D3445B /* MorphicA11yAuthorization.swift */,
 				9D0AF73624A0FB67007E177E /* MorphicA11yUIAttributeValueCompatible.swift */,
 				9D0AF73824A0FB78007E177E /* MorphicA11yUIElement.swift */,
 				315EEC8424A536290039C61D /* UIElement.swift */,
@@ -522,6 +525,7 @@
 				31F9AEDD24A7F2D90026EBDA /* AccessibilityUIAutomation.swift in Sources */,
 				3137AC4424B0FBC600CE3808 /* MenuItemElement.swift in Sources */,
 				315EEC8324A530970039C61D /* SystemPreferences.swift in Sources */,
+				9DCE209224CF1AAF00D3445B /* MorphicA11yAuthorization.swift in Sources */,
 				31A16BCF2423E86C0081A72C /* MorphicDisk.swift in Sources */,
 				3113364D2427F01100686AF6 /* SettingsManager.swift in Sources */,
 				31A16BCD2423E86C0081A72C /* MorphicInput.swift in Sources */,

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/ApplicationElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/ApplicationElement.swift
@@ -70,7 +70,17 @@ public class ApplicationElement: UIElement{
                     completion(false)
                     return
                 }
-                guard let accessibilityElement = MorphicA11yUIElement.createFromProcess(processIdentifier: runningApplication.processIdentifier) else{
+                //
+                var accessibilityElement: MorphicA11yUIElement? = nil
+                do {
+                    accessibilityElement = try MorphicA11yUIElement.createFromProcess(processIdentifier: runningApplication.processIdentifier)
+                } catch MorphicA11yAuthorizationError.notAuthorized {
+                    // prompt the user to grant our application accessibility permissions
+                    MorphicA11yAuthorization.promptUserToGrantAuthorization()
+                } catch {
+                    // no other errors should be throws by MorphicA11yUIElement.createFromProcess
+                }
+                guard accessibilityElement != nil else{
                     os_log(.error, log: logger, "Failed to get automation element for application")
                     completion(false)
                     return

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/MorphicA11yAuthorization.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/MorphicA11yAuthorization.swift
@@ -1,0 +1,60 @@
+// Copyright 2020 Raising the Floor - International
+//
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
+//
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
+//
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
+
+public enum MorphicA11yAuthorizationError: Error {
+    case notAuthorized
+}
+
+public struct MorphicA11yAuthorization {
+    public static func authorizationStatus() -> Bool {
+        return AXIsProcessTrusted()
+    }
+
+    public static func authorizationStatus(promptIfNotAuthorized: Bool) -> Bool {
+        // NOTE: kAXTrustedCheckOptionPrompt is a global variable (CFStringRef), so we need to capture an unretained copy
+        let axTrustedCheckOptionPromptAsCFString = kAXTrustedCheckOptionPrompt.takeUnretainedValue()
+        
+        let optionsAsNSDictionary: NSDictionary = [
+            axTrustedCheckOptionPromptAsCFString: promptIfNotAuthorized
+        ]
+        let optionsAsCFDictionary = optionsAsNSDictionary as CFDictionary
+        
+        // NOTE: this function call also adds Morphic to the list of possible applications to authorize in the accessibility section
+        return AXIsProcessTrustedWithOptions(optionsAsCFDictionary)
+    }
+    
+    public static func promptUserToGrantAuthorization() {
+        _ = authorizationStatus(promptIfNotAuthorized: true)
+    }
+    
+    // NOTE: in the future, we may want to consider watching for authorization state changes
+    // NOTE: this code is just conceptual code; it would need to be thought through and vetted, and ideally the caller would also call DistributedNotificationCenter.default().removeObserver(...) once the watch was no longer desired
+    // NOTE: the callback (which might also be better accomplished via a selector) would likely be called for permission changes in any application, so adding a filter for our current application (which would then call a function with a Boolean authorized/unauthorized value) would be useful.
+    // NOTE: our code might need to wait a small delay after the callback is called, as the permissions state could potentially lag the callback by milliseconds (or even hundreds of milliseconds)
+//    public static func watchForAuthorizationStatusChange(callback: @escaping (Bool) -> ()) {
+//        let accessibilityApiNotificationName = NSNotification.Name("com.apple.accessibility.api")
+//        DistributedNotificationCenter.default().addObserver(forName: accessibilityApiNotificationName, object: nil, queue: nil) { notification in
+//            callback(/* true or false */)
+//        }
+//    }
+}

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/MorphicA11yUIElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/MorphicA11yUIElement.swift
@@ -62,8 +62,12 @@ public struct MorphicA11yUIElement {
         }
     }
     
-    // TODO: consider adding "throws" if we don't have permission
-    public static func createFromProcess(processIdentifier: pid_t) -> MorphicA11yUIElement? {
+    public static func createFromProcess(processIdentifier: pid_t) throws -> MorphicA11yUIElement? {
+        // verify that the application has accessibility authorization; if it does not, do not prompt the user (as we want the application to control the authorization pop-ups)
+        guard MorphicA11yAuthorization.authorizationStatus(promptIfNotAuthorized: false) == true else {
+            throw MorphicA11yAuthorizationError.notAuthorized
+        }
+
         // get a reference to the top-level accessibility object for this process
         let topLevelAccessibilityObject = AXUIElementCreateApplication(processIdentifier)
         return MorphicA11yUIElement(axUiElement: topLevelAccessibilityObject)


### PR DESCRIPTION
I have added a notAuthorized error to the MorphicA11y "createFromProcess" function.  Calling the function with "try? " results in the previously-defined behavior, and calling it with "try " allows the caller to capture the authorization failure during a11y object creation.

I also added a MorphicA11yAuthorization class which lets code detect authorization status, prompt the user for authorization permission, and verify authorization status while falling back to prompting the user for authorization permission.

I updated the Morphic GUI accessibility code which calls createFromProcess so that it takes advantage of all of the above.

The end effect is that users are now prompted to give Morphic for macOS the proper accessibility permission--even if they previously denied permission to the app (or revoked it via System Preferences).

Future potential improvements:
- dynamically watch for changes in accessibility authorization (I added in some commented-out pseudo-code for this) for an optimal user experience
- instead of prompting the user to "open system preferences or deny", we could _maybe_ open up the system preferences pane via NSWorkspace.shared's open url function (if we have sufficient permissions), for a really nice "guided experience."
- place an "instructions pane" next to the System Preferences app so that the user has step-by-step instructions on how to give Morphic for macOS the required authorization.