### PR TITLE
lint, add copyright blocks and swiftify MorphicManualTester

### DIFF
--- a/Morphic/Morphic/AppDelegate.swift
+++ b/Morphic/Morphic/AppDelegate.swift
@@ -67,12 +67,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     // MARK: - Notifications
     
     @objc
-    func userDidSignin(_ notification: NSNotification){
+    func userDidSignin(_ notification: NSNotification) {
         os_log(.info, log: logger, "Got signin notification from configurator")
         Session.shared.open {
             NotificationCenter.default.post(name: .morphicSessionUserDidChange, object: Session.shared)
             let userInfo = notification.userInfo ?? [:]
-            if !(userInfo["isRegister"] as? Bool ?? false){
+            if !(userInfo["isRegister"] as? Bool ?? false) {
                 os_log(.info, log: logger, "Is not a registration signin, applying all preferences")
                 Session.shared.applyAllPreferences {
                 }
@@ -81,8 +81,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
     
     @objc
-    func sessionUserDidChange(_ notification: NSNotification){
-        guard let session = notification.object as? Session else{
+    func sessionUserDidChange(_ notification: NSNotification) {
+        guard let session = notification.object as? Session else {
             return
         }
         self.logoutItem?.isHidden = session.user == nil
@@ -91,15 +91,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     // MARK: - Actions
     
     @IBAction
-    func logout(_ sender: Any){
+    func logout(_ sender: Any) {
         Session.shared.signout {
             self.logoutItem?.isHidden = true
         }
     }
     
     @IBAction
-    func reapplyAllSettings(_ sender: Any){
-        Session.shared.open{
+    func reapplyAllSettings(_ sender: Any) {
+        Session.shared.open {
             os_log(.info, "Re-applying all settings")
             Session.shared.applyAllPreferences {
                 
@@ -108,7 +108,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
     
     @IBAction
-    func captureAllSettings(_ sender: Any){
+    func captureAllSettings(_ sender: Any) {
         let prefs = Preferences(identifier: "")
         let capture = CaptureSession(settingsManager: Session.shared.settings, preferences: prefs)
         capture.captureDefaultValues = true
@@ -124,35 +124,35 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     
     func createEmptyDefaultPreferencesIfNotExist(completion: @escaping () -> Void) {
         let prefs = Preferences(identifier: "__default__")
-        guard !Session.shared.storage.contains(identifier: prefs.identifier, type: Preferences.self) else{
+        guard !Session.shared.storage.contains(identifier: prefs.identifier, type: Preferences.self) else {
             completion()
             return
         }
-        Session.shared.storage.save(record: prefs){
+        Session.shared.storage.save(record: prefs) {
             success in
-            if !success{
+            if !success {
                 os_log(.error, log: logger, "Failed to save default preferences")
             }
             completion()
         }
     }
      
-    func loadInitialDefaultPreferences(){
+    func loadInitialDefaultPreferences() {
         // load our initial default preferences
         var initialPrefs = Preferences(identifier: "__initial__")
         
-        guard let url = Bundle.main.url(forResource: "DefaultPreferences", withExtension: "json") else{
+        guard let url = Bundle.main.url(forResource: "DefaultPreferences", withExtension: "json") else {
             os_log(.error, log: logger, "Failed to find default preferences")
             return
         }
-        guard let json = FileManager.default.contents(atPath: url.path) else{
+        guard let json = FileManager.default.contents(atPath: url.path) else {
             os_log(.error, log: logger, "Failed to read default preferences")
             return
         }
-        do{
+        do {
             let decoder = JSONDecoder()
             initialPrefs.defaults = try decoder.decode(Preferences.PreferencesSet.self, from: json)
-        }catch{
+        } catch {
             os_log(.error, log: logger, "Failed to decode default preferences")
             return
         }
@@ -162,7 +162,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
    
     // MARK: - Solutions
     
-    func populateSolutions(){
+    func populateSolutions() {
         Session.shared.settings.populateSolutions(fromResource: "macos.solutions")
     }
      
@@ -193,8 +193,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     ///
     /// - parameter sender: The UI element that caused this action to be invoked
     @IBAction
-    func toggleMorphicBar(_ sender: Any?){
-        if morphicBarWindow != nil{
+    func toggleMorphicBar(_ sender: Any?) {
+        if morphicBarWindow != nil {
             hideMorphicBar(nil)
         }else{
             showMorphicBar(nil)
@@ -202,8 +202,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
     
     @IBAction
-    func showMorphicBar(_ sender: Any?){
-        if morphicBarWindow == nil{
+    func showMorphicBar(_ sender: Any?) {
+        if morphicBarWindow == nil {
             morphicBarWindow = MorphicBarWindow()
             morphicBarWindow?.delegate = self
         }
@@ -217,7 +217,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
     
     @IBAction
-    func hideMorphicBar(_ sender: Any?){
+    func hideMorphicBar(_ sender: Any?) {
         morphicBarWindow?.close()
         showMorphicBarItem?.isHidden = false
         hideMorphicBarItem?.isHidden = true
@@ -244,27 +244,27 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     // MARK: - Configurator App
     
     @IBAction
-    func launchCapture(_ sender: Any?){
+    func launchCapture(_ sender: Any?) {
         launchConfigurator(argument: "capture")
     }
     
     @IBAction
-    func launchLogin(_ sender: Any?){
+    func launchLogin(_ sender: Any?) {
         launchConfigurator(argument: "login")
     }
     
-    func launchConfigurator(argument: String){
+    func launchConfigurator(argument: String) {
 //        let url = URL(string: "morphicconfig:\(argument)")!
 //        NSWorkspace.shared.open(url)
         os_log(.info, log: logger, "launching configurator")
-        guard let url = Bundle.main.resourceURL?.deletingLastPathComponent().appendingPathComponent("Library").appendingPathComponent("MorphicConfigurator.app") else{
+        guard let url = Bundle.main.resourceURL?.deletingLastPathComponent().appendingPathComponent("Library").appendingPathComponent("MorphicConfigurator.app") else {
             os_log(.error, log: logger, "Failed to construct bundled configurator app URL")
             return
         }
         let config = NSWorkspace.OpenConfiguration()
         config.activates = true
         config.arguments = [argument]
-        NSWorkspace.shared.openApplication(at: url, configuration: config){
+        NSWorkspace.shared.openApplication(at: url, configuration: config) {
             (app, error) in
             guard error == nil else{
                 os_log(.error, log: logger, "Failed to launch configurator: %{public}s", error!.localizedDescription)

--- a/Morphic/Morphic/CreateDiskImage.sh
+++ b/Morphic/Morphic/CreateDiskImage.sh
@@ -1,10 +1,27 @@
 #!/bin/sh
 
-#  CreateDiskImage.sh
-#  Morphic
+#  Copyright 2020 Raising the Floor - International
 #
-#  Created by Owen Shaw on 5/29/20.
-#  Copyright © 2020 Raising the Floor. All rights reserved.
+#  Licensed under the New BSD license. You may not use this file except in
+#  compliance with this License.
+#
+#  You may obtain a copy of the License at
+#  https://github.com/GPII/universal/blob/master/LICENSE.txt
+#
+#  The R&D leading to these results received funding from the:
+#  * Rehabilitation Services Administration, US Dept. of Education under
+#    grant H421A150006 (APCP)
+#  * National Institute on Disability, Independent Living, and
+#    Rehabilitation Research (NIDILRR)
+#  * Administration for Independent Living & Dept. of Education under grants
+#    H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+#  * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+#    agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+#  * William and Flora Hewlett Foundation
+#  * Ontario Ministry of Research and Innovation
+#  * Canadian Foundation for Innovation
+#  * Adobe Foundation
+#  * Consumer Electronics Association Foundation
 
 echo "---- Running CreateDiskImage.sh -----"
 

--- a/Morphic/Morphic/Help Window/PageControl.swift
+++ b/Morphic/Morphic/Help Window/PageControl.swift
@@ -1,44 +1,59 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  PageControl.swift
-//  Morphic
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by Owen Shaw on 7/4/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import Cocoa
 
 class PageControl: NSView {
     
-    public var numberOfPages: Int = 1{
-        didSet{
+    public var numberOfPages: Int = 1 {
+        didSet {
             invalidateIntrinsicContentSize()
             setNeedsDisplay(bounds)
         }
     }
     
-    public var selectedPage: Int = -1{
-        didSet{
+    public var selectedPage: Int = -1 {
+        didSet {
             setNeedsDisplay(bounds)
         }
     }
     
     @IBInspectable
-    public var dotColor: NSColor = .white{
-        didSet{
+    public var dotColor: NSColor = .white {
+        didSet {
             setNeedsDisplay(bounds)
         }
     }
     
-    public var dotSize: CGFloat{
+    public var dotSize: CGFloat {
         bounds.height
     }
     
-    public var dotSpacing: CGFloat{
+    public var dotSpacing: CGFloat {
         dotSize
     }
     
-    override var intrinsicContentSize: NSSize{
+    override var intrinsicContentSize: NSSize {
         return NSSize(width: CGFloat(numberOfPages) * dotSize + CGFloat(numberOfPages - 1) * dotSpacing, height: NSView.noIntrinsicMetric)
     }
 
@@ -52,9 +67,9 @@ class PageControl: NSView {
         context.setStrokeColor(dotColor.cgColor)
         context.setLineWidth(1.0)
         var x: CGFloat = 0
-        for i in 0..<numberOfPages{
+        for i in 0..<numberOfPages {
             let rect = CGRect(x: x, y: 0, width: dotSize, height: dotSize)
-            if i == selectedPage{
+            if i == selectedPage {
                 context.fillEllipse(in: rect)
             }else{
                 context.strokeEllipse(in: rect)

--- a/Morphic/Morphic/Help Window/ProgressIndicator.swift
+++ b/Morphic/Morphic/Help Window/ProgressIndicator.swift
@@ -1,10 +1,25 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  ProgressIndicator.swift
-//  Morphic
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by Owen Shaw on 7/4/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import Cocoa
 
@@ -20,7 +35,7 @@ class ProgressIndicator: NSView {
         commonInit()
     }
     
-    func commonInit(){
+    func commonInit() {
         wantsLayer = true
         layer?.masksToBounds = true
         layer?.borderWidth = borderWidth
@@ -34,33 +49,33 @@ class ProgressIndicator: NSView {
     private var barLayer = CALayer()
     
     @IBInspectable
-    public var barColor: NSColor = .white{
-        didSet{
+    public var barColor: NSColor = .white {
+        didSet {
             barLayer.backgroundColor = barColor.cgColor
             setNeedsDisplay(bounds)
         }
     }
     
     @IBInspectable
-    public var borderColor: NSColor = .white{
-        didSet{
+    public var borderColor: NSColor = .white {
+        didSet {
             layer?.borderColor = borderColor.cgColor
         }
     }
     
-    public var borderWidth: CGFloat = 1.0{
-        didSet{
+    public var borderWidth: CGFloat = 1.0 {
+        didSet {
             layer?.borderWidth = borderWidth
         }
     }
     
-    public var doubleValue: Double = 0.0{
-        didSet{
+    public var doubleValue: Double = 0.0 {
+        didSet {
             updateBar()
         }
     }
     
-    func updateBar(){
+    func updateBar() {
         barLayer.frame = CGRect(x: 0, y: 0, width: bounds.width * CGFloat(doubleValue), height: bounds.height)
     }
     

--- a/Morphic/Morphic/Help Window/QuickHelpContentProvider.swift
+++ b/Morphic/Morphic/Help Window/QuickHelpContentProvider.swift
@@ -1,10 +1,25 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  QuickHelpContentProvider.swift
-//  Morphic
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by Owen Shaw on 7/4/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import Cocoa
 

--- a/Morphic/Morphic/Help Window/QuickHelpStepViewController.swift
+++ b/Morphic/Morphic/Help Window/QuickHelpStepViewController.swift
@@ -1,10 +1,25 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  QuickHelpStepViewController.swift
-//  Morphic
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by Owen Shaw on 7/4/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import Cocoa
 
@@ -31,40 +46,40 @@ class QuickHelpStepViewController: NSViewController {
     }
     
     /// The text to display in the title label
-    public var titleText: String = ""{
+    public var titleText: String = "" {
         didSet{
             updateTitleLabel()
         }
     }
     
-    public func updateTitleLabel(){
+    public func updateTitleLabel() {
         titleLabel?.stringValue = titleText
     }
     
     /// The text to display in the message label
-    public var messageText: String = ""{
-        didSet{
+    public var messageText: String = "" {
+        didSet {
             updateMessageLabel()
         }
     }
     
-    public func updateMessageLabel(){
+    public func updateMessageLabel() {
         messageLabel?.stringValue = messageText
     }
     
-    public var numberOfSteps: Int = 1{
-        didSet{
+    public var numberOfSteps: Int = 1 {
+        didSet {
             updateStep()
         }
     }
     
-    public var step: Int = 0{
-        didSet{
+    public var step: Int = 0 {
+        didSet {
             updateStep()
         }
     }
     
-    public func updateStep(){
+    public func updateStep() {
         pageControl?.numberOfPages = numberOfSteps
         pageControl?.selectedPage = step
     }

--- a/Morphic/Morphic/Help Window/QuickHelpViewController.swift
+++ b/Morphic/Morphic/Help Window/QuickHelpViewController.swift
@@ -41,15 +41,15 @@ class QuickHelpViewController: NSViewController {
     }
     
     /// The text to display in the title label
-    public var titleText: String = ""{
-        didSet{
+    public var titleText: String = "" {
+        didSet {
             titleLabel?.stringValue = titleText
         }
     }
     
     /// The text to display in the message label
-    public var messageText: String = ""{
-        didSet{
+    public var messageText: String = "" {
+        didSet {
             messageLabel?.stringValue = messageText
         }
     }

--- a/Morphic/Morphic/Help Window/QuickHelpVolumeViewController.swift
+++ b/Morphic/Morphic/Help Window/QuickHelpVolumeViewController.swift
@@ -1,10 +1,25 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  QuickHelpVolumeViewController.swift
-//  Morphic
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by Owen Shaw on 7/4/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import Cocoa
 
@@ -34,49 +49,49 @@ class QuickHelpVolumeViewController: NSViewController {
     }
     
     /// The text to display in the title label
-    public var titleText: String = ""{
-        didSet{
+    public var titleText: String = "" {
+        didSet {
             updateTitleLabel()
         }
     }
     
-    public func updateTitleLabel(){
+    public func updateTitleLabel() {
         titleLabel?.stringValue = titleText
     }
     
     /// The text to display in the message label
-    public var messageText: String = ""{
-        didSet{
+    public var messageText: String = "" {
+        didSet {
             updateMessageLabel()
         }
     }
     
-    public func updateMessageLabel(){
+    public func updateMessageLabel() {
         messageLabel?.stringValue = messageText
     }
     
-    public var volumeLevel: Double = 0.0{
-        didSet{
+    public var volumeLevel: Double = 0.0 {
+        didSet {
             updateVolume()
         }
     }
     
-    public func updateVolume(){
+    public func updateVolume() {
         progressLabel?.stringValue = percentageFormatter.string(from: NSNumber(floatLiteral: volumeLevel))!
         progressBar?.doubleValue = volumeLevel
     }
     
-    public var muted: Bool = false{
-        didSet{
+    public var muted: Bool = false {
+        didSet {
             updateMuted()
         }
     }
     
-    public func updateMuted(){
-        if muted{
+    public func updateMuted() {
+        if muted {
             progressLabel?.alphaValue = 0.5
             progressBar?.alphaValue = 0.5
-        }else{
+        } else {
             progressLabel?.alphaValue = 1
             progressBar?.alphaValue = 1
         }

--- a/Morphic/Morphic/Help Window/QuickHelpWindow.swift
+++ b/Morphic/Morphic/Help Window/QuickHelpWindow.swift
@@ -29,7 +29,7 @@ import Cocoa
 class QuickHelpWindow: NSWindow {
     
     /// Create a new Quick Help Window with a `QuickHelpViewController` as its `contentViewController`
-    private init(){
+    private init() {
         super.init(contentRect: NSMakeRect(0, 0, 100, 100), styleMask: .borderless, backing: .buffered, defer: false)
         hasShadow = true
         isReleasedWhenClosed = false
@@ -48,7 +48,7 @@ class QuickHelpWindow: NSWindow {
     /// - parameters:
     ///   - title: The text to show in the view controller's `titleLabel`
     ///   - message: The text to show in the view controller's `messageLabel`
-    public static func show(viewController: NSViewController){
+    public static func show(viewController: NSViewController) {
         if shared == nil{
             shared = QuickHelpWindow()
             shared?.delegate = delegate
@@ -68,7 +68,7 @@ class QuickHelpWindow: NSWindow {
     ///
     /// Since the user is likely to be moving from the button calling `hide()` to another that will call
     /// `show()`, the window doesn't close until a short delay has passed without a `show()` call.
-    public static func hide(){
+    public static func hide() {
         shared?.hideQueued = true
         Timer.scheduledTimer(withTimeInterval: 0.2, repeats: false){
             timer in
@@ -79,27 +79,27 @@ class QuickHelpWindow: NSWindow {
         }
     }
     
-    override var canBecomeKey: Bool{
+    override var canBecomeKey: Bool {
         return false
     }
     
-    override var canBecomeMain: Bool{
+    override var canBecomeMain: Bool {
         return false
     }
     
     /// Center the window in the screen
-    func reposition(){
-        guard let screen = screen else{
+    func reposition() {
+        guard let screen = screen else {
             return
         }
         let frame = NSRect(x: round((screen.frame.width - self.frame.size.width) / 2), y: round((screen.frame.height - self.frame.size.height) / 2), width: self.frame.size.width, height: self.frame.size.height)
         setFrame(frame, display: true, animate: false)
     }
     
-    class Delegate: NSObject, NSWindowDelegate{
+    class Delegate: NSObject, NSWindowDelegate {
         
         func windowDidChangeScreen(_ notification: Notification) {
-            guard let window = notification.object as? QuickHelpWindow else{
+            guard let window = notification.object as? QuickHelpWindow else {
                 return
             }
             window.reposition()

--- a/Morphic/Morphic/Help Window/ShadowedLabel.swift
+++ b/Morphic/Morphic/Help Window/ShadowedLabel.swift
@@ -38,7 +38,7 @@ public class ShadowedLabel: NSTextField {
     /// The shadow created from the other `textShadow*` properties
     ///
     /// - note: The other properties are split out so they can be individually `IBInspectable`
-    public var textShadow: NSShadow{
+    public var textShadow: NSShadow {
         let shadow = NSShadow()
         shadow.shadowColor = textShadowColor
         shadow.shadowOffset = textShadowOffset
@@ -46,11 +46,11 @@ public class ShadowedLabel: NSTextField {
         return shadow
     }
     
-    public override var stringValue: String{
-        get{
+    public override var stringValue: String {
+        get {
             return super.stringValue
         }
-        set{
+        set {
             super.stringValue = newValue
             // take whatever atttributed string NSTextField creates in its base implementation
             // and add the attribute that makes a text shadow.  This method ensures we don't lose any
@@ -61,7 +61,7 @@ public class ShadowedLabel: NSTextField {
         }
     }
     
-    public override var intrinsicContentSize: NSSize{
+    public override var intrinsicContentSize: NSSize {
         var size = super.intrinsicContentSize
         // Pad the intrinsic content size so the text shadow isn't cut off
         size.height += 4

--- a/Morphic/Morphic/MorphicBar/MorphicBarItem.swift
+++ b/Morphic/Morphic/MorphicBar/MorphicBarItem.swift
@@ -26,23 +26,23 @@ import MorphicCore
 import MorphicSettings
 import MorphicService
 
-public class MorphicBarItem{
+public class MorphicBarItem {
     
     var interoperable: [String: Interoperable?]
     
-    public init(interoperable: [String: Interoperable?]){
+    public init(interoperable: [String: Interoperable?]) {
         self.interoperable = interoperable
     }
     
-    func view() -> MorphicBarItemView?{
+    func view() -> MorphicBarItemView? {
         return nil
     }
     
-    public static func items(from interoperables: [Interoperable?]) -> [MorphicBarItem]{
+    public static func items(from interoperables: [Interoperable?]) -> [MorphicBarItem] {
         var items = [MorphicBarItem]()
-        for i in 0..<interoperables.count{
-            if let dict = interoperables.dictionary(at: i){
-                if let item_ = item(from: dict){
+        for i in 0..<interoperables.count {
+            if let dict = interoperables.dictionary(at: i) {
+                if let item_ = item(from: dict) {
                     items.append(item_)
                 }
             }
@@ -50,8 +50,8 @@ public class MorphicBarItem{
         return items
     }
     
-    public static func item(from interoperable: [String: Interoperable?]) -> MorphicBarItem?{
-        switch interoperable.string(for: "type"){
+    public static func item(from interoperable: [String: Interoperable?]) -> MorphicBarItem? {
+        switch interoperable.string(for: "type") {
         case "control":
             return MorphicBarControlItem(interoperable: interoperable)
         default:
@@ -63,7 +63,7 @@ public class MorphicBarItem{
 
 class MorphicBarControlItem: MorphicBarItem{
     
-    enum Feature: String{
+    enum Feature: String {
         case resolution
         case magnifier
         case reader
@@ -71,8 +71,8 @@ class MorphicBarControlItem: MorphicBarItem{
         case contrast
         case unknown
         
-        init(string: String?){
-            if let known = Feature(rawValue: string ?? ""){
+        init(string: String?) {
+            if let known = Feature(rawValue: string ?? "") {
                 self = known
             }else{
                 self = .unknown
@@ -88,7 +88,7 @@ class MorphicBarControlItem: MorphicBarItem{
     }
     
     override func view() -> MorphicBarItemView? {
-        switch feature{
+        switch feature {
         case .resolution:
             let localized = LocalizedStrings(prefix: "control.feature.resolution")
             let segments = [
@@ -155,86 +155,86 @@ class MorphicBarControlItem: MorphicBarItem{
     }
     
     @objc
-    func zoom(_ sender: Any?){
-        guard let segment = (sender as? MorphicBarSegmentedButton)?.integerValue else{
+    func zoom(_ sender: Any?) {
+        guard let segment = (sender as? MorphicBarSegmentedButton)?.integerValue else {
             return
         }
-        guard let display = Display.main else{
+        guard let display = Display.main else {
             return
         }
         var percentage: Double
-        if segment == 0{
+        if segment == 0 {
             percentage = display.percentage(zoomingIn: 1)
-        }else{
+        } else {
             percentage = display.percentage(zoomingOut: 1)
         }
         _ = display.zoom(to: percentage)
     }
     
     @objc
-    func volume(_ sender: Any?){
-        guard let segment = (sender as? MorphicBarSegmentedButton)?.integerValue else{
+    func volume(_ sender: Any?) {
+        guard let segment = (sender as? MorphicBarSegmentedButton)?.integerValue else {
             return
         }
-        guard let output = AudioOutput.main else{
+        guard let output = AudioOutput.main else {
             return
         }
-        if segment == 0{
-            if output.isMuted{
+        if segment == 0 {
+            if output.isMuted {
                 _ = output.setMuted(false)
-            }else{
+            } else {
                 _ = output.setVolume(output.volume + 0.1)
             }
-        }else if segment == 1{
+        } else if segment == 1 {
             if output.isMuted{
                 _ = output.setMuted(false)
-            }else{
+            } else {
                 _ = output.setVolume(output.volume - 0.1)
             }
-        }else if segment == 2{
+        } else if segment == 2 {
             _ = output.setMuted(true)
         }
     }
     
     @objc
-    func contrast(_ sender: Any?){
-        guard let segment = (sender as? MorphicBarSegmentedButton)?.integerValue else{
+    func contrast(_ sender: Any?) {
+        guard let segment = (sender as? MorphicBarSegmentedButton)?.integerValue else {
             return
         }
-        if segment == 0{
-            Session.shared.apply(true, for: .macosDisplayContrastEnabled){
+        if segment == 0 {
+            Session.shared.apply(true, for: .macosDisplayContrastEnabled) {
                 _ in
             }
-        }else{
-            Session.shared.apply(false, for: .macosDisplayContrastEnabled){
+        } else {
+            Session.shared.apply(false, for: .macosDisplayContrastEnabled) {
                 _ in
             }
         }
     }
     
     @objc
-    func reader(_ sender: Any?){
-        guard let segment = (sender as? MorphicBarSegmentedButton)?.integerValue else{
+    func reader(_ sender: Any?) {
+        guard let segment = (sender as? MorphicBarSegmentedButton)?.integerValue else {
             return
         }
-        if segment == 0{
-            Session.shared.apply(true, for: .macosVoiceOverEnabled){
+        if segment == 0 {
+            Session.shared.apply(true, for: .macosVoiceOverEnabled) {
                 _ in
             }
-        }else{
-            Session.shared.apply(false, for: .macosVoiceOverEnabled){
+        } else {
+            Session.shared.apply(false, for: .macosVoiceOverEnabled) {
                 _ in
             }
         }
     }
     
     @objc
-    func magnifier(_ sender: Any?){
-        guard let segment = (sender as? MorphicBarSegmentedButton)?.integerValue else{
+    func magnifier(_ sender: Any?) {
+        guard let segment = (sender as? MorphicBarSegmentedButton)?.integerValue else {
             return
         }
         let session = Session.shared
-        if segment == 0{
+        if segment == 0 {
             let keyValuesToSet: [(Preferences.Key, Interoperable?)] = [
                 (.macosZoomStyle, 1)
             ]
@@ -243,7 +243,7 @@ class MorphicBarControlItem: MorphicBarItem{
             capture.keys = keyValuesToSet.map{ $0.0 }
             capture.captureDefaultValues = true
             capture.run {
-                session.storage.save(record: capture.preferences){
+                session.storage.save(record: capture.preferences) {
                     _ in
                     let apply = ApplySession(settingsManager: session.settings, keyValueTuples: keyValuesToSet)
                     apply.add(key: .macosZoomEnabled, value: true)
@@ -252,14 +252,14 @@ class MorphicBarControlItem: MorphicBarItem{
                 }
             }
         }else{
-            session.storage.load(identifier: "__magnifier__"){
+            session.storage.load(identifier: "__magnifier__") {
                 (preferences: Preferences?) in
-                if let preferences = preferences{
+                if let preferences = preferences {
                     let apply = ApplySession(settingsManager: session.settings, preferences: preferences)
                     apply.addFirst(key: .macosZoomEnabled, value: false)
                     apply.run {
                     }
-                }else{
+                } else {
                     session.apply(false, for: .macosZoomEnabled){
                         _ in
                     }
@@ -270,17 +270,17 @@ class MorphicBarControlItem: MorphicBarItem{
     
 }
 
-fileprivate struct LocalizedStrings{
+fileprivate struct LocalizedStrings {
     
     var prefix: String
     var table = "MorphicBarViewController"
     var bundle = Bundle.main
     
-    init(prefix: String){
+    init(prefix: String) {
         self.prefix = prefix
     }
     
-    func string(for suffix: String) -> String{
+    func string(for suffix: String) -> String {
         return bundle.localizedString(forKey: prefix + "." + suffix, value: nil, table: table)
     }
 }
@@ -289,7 +289,7 @@ fileprivate class QuickHelpDynamicTextProvider: QuickHelpContentProvider{
     
     var textProvider: () -> (String, String)?
     
-    init(textProvider: @escaping () -> (String, String)?){
+    init(textProvider: @escaping () -> (String, String)?) {
         self.textProvider = textProvider
     }
     
@@ -304,9 +304,9 @@ fileprivate class QuickHelpDynamicTextProvider: QuickHelpContentProvider{
     }
 }
 
-fileprivate class QuickHelpTextSizeBiggerProvider: QuickHelpContentProvider{
+fileprivate class QuickHelpTextSizeBiggerProvider: QuickHelpContentProvider {
     
-    init(display: Display?, localized: LocalizedStrings){
+    init(display: Display?, localized: LocalizedStrings) {
         self.display = display
         self.localized = localized
     }
@@ -323,10 +323,10 @@ fileprivate class QuickHelpTextSizeBiggerProvider: QuickHelpContentProvider{
         }
         viewController.numberOfSteps = total
         viewController.step = step
-        if step == total - 1{
+        if step == total - 1 {
             viewController.titleText = localized.string(for: "bigger.limit.help.title")
             viewController.messageText = localized.string(for: "bigger.limit.help.message")
-        }else{
+        } else {
             viewController.titleText = localized.string(for: "bigger.help.title")
             viewController.messageText = localized.string(for: "bigger.help.message")
         }
@@ -334,9 +334,9 @@ fileprivate class QuickHelpTextSizeBiggerProvider: QuickHelpContentProvider{
     }
 }
 
-fileprivate class QuickHelpTextSizeSmallerProvider: QuickHelpContentProvider{
+fileprivate class QuickHelpTextSizeSmallerProvider: QuickHelpContentProvider {
     
-    init(display: Display?, localized: LocalizedStrings){
+    init(display: Display?, localized: LocalizedStrings) {
         self.display = display
         self.localized = localized
     }
@@ -348,15 +348,15 @@ fileprivate class QuickHelpTextSizeSmallerProvider: QuickHelpContentProvider{
         let viewController = QuickHelpStepViewController(nibName: "QuickHelpStepViewController", bundle: nil)
         let total = display?.numberOfSteps ?? 1
         var step = display?.currentStep ?? -1
-        if step >= 0{
+        if step >= 0 {
             step = total - 1 - step
         }
         viewController.numberOfSteps = total
         viewController.step = step
-        if step == 0{
+        if step == 0 {
             viewController.titleText = localized.string(for: "smaller.limit.help.title")
             viewController.messageText = localized.string(for: "smaller.limit.help.message")
-        }else{
+        } else {
             viewController.titleText = localized.string(for: "smaller.help.title")
             viewController.messageText = localized.string(for: "smaller.help.message")
         }
@@ -366,7 +366,7 @@ fileprivate class QuickHelpTextSizeSmallerProvider: QuickHelpContentProvider{
 
 fileprivate class QuickHelpVolumeUpProvider: QuickHelpContentProvider{
     
-    init(audioOutput: AudioOutput?, localized: LocalizedStrings){
+    init(audioOutput: AudioOutput?, localized: LocalizedStrings) {
         output = audioOutput
         self.localized = localized
     }
@@ -380,14 +380,14 @@ fileprivate class QuickHelpVolumeUpProvider: QuickHelpContentProvider{
         let viewController = QuickHelpVolumeViewController(nibName: "QuickHelpVolumeViewController", bundle: nil)
         viewController.volumeLevel = level
         viewController.muted = muted
-        if muted{
+        if muted {
             viewController.titleText = localized.string(for: "up.muted.help.title")
             viewController.messageText = localized.string(for: "up.muted.help.message")
-        }else{
-            if level >= 0.99{
+        } else {
+            if level >= 0.99 {
                 viewController.titleText = localized.string(for: "up.limit.help.title")
                 viewController.messageText = localized.string(for: "up.limit.help.message")
-            }else{
+            } else {
                 viewController.titleText = localized.string(for: "up.help.title")
                 viewController.messageText = localized.string(for: "up.help.message")
             }
@@ -399,7 +399,7 @@ fileprivate class QuickHelpVolumeUpProvider: QuickHelpContentProvider{
 
 fileprivate class QuickHelpVolumeDownProvider: QuickHelpContentProvider{
     
-    init(audioOutput: AudioOutput?, localized: LocalizedStrings){
+    init(audioOutput: AudioOutput?, localized: LocalizedStrings) {
         output = audioOutput
         self.localized = localized
     }
@@ -413,14 +413,14 @@ fileprivate class QuickHelpVolumeDownProvider: QuickHelpContentProvider{
         let viewController = QuickHelpVolumeViewController(nibName: "QuickHelpVolumeViewController", bundle: nil)
         viewController.volumeLevel = level
         viewController.muted = muted
-        if muted{
+        if muted {
             viewController.titleText = localized.string(for: "down.muted.help.title")
             viewController.messageText = localized.string(for: "down.muted.help.message")
-        }else{
+        } else {
             if level <= 0.01{
                 viewController.titleText = localized.string(for: "down.limit.help.title")
                 viewController.messageText = localized.string(for: "down.limit.help.message")
-            }else{
+            } else {
                 viewController.titleText = localized.string(for: "down.help.title")
                 viewController.messageText = localized.string(for: "down.help.message")
             }
@@ -432,7 +432,7 @@ fileprivate class QuickHelpVolumeDownProvider: QuickHelpContentProvider{
 
 fileprivate class QuickHelpVolumeMuteProvider: QuickHelpContentProvider{
     
-    init(audioOutput: AudioOutput?, localized: LocalizedStrings){
+    init(audioOutput: AudioOutput?, localized: LocalizedStrings) {
         output = audioOutput
         self.localized = localized
     }
@@ -446,10 +446,10 @@ fileprivate class QuickHelpVolumeMuteProvider: QuickHelpContentProvider{
         let viewController = QuickHelpVolumeViewController(nibName: "QuickHelpVolumeViewController", bundle: nil)
         viewController.volumeLevel = level
         viewController.muted = muted
-        if muted{
+        if muted {
             viewController.titleText = localized.string(for: "muted.help.title")
             viewController.messageText = localized.string(for: "muted.help.message")
-        }else{
+        } else {
             viewController.titleText = localized.string(for: "mute.help.title")
             viewController.messageText = localized.string(for: "mute.help.message")
         }
@@ -460,11 +460,11 @@ fileprivate class QuickHelpVolumeMuteProvider: QuickHelpContentProvider{
 
 private extension NSImage{
     
-    static func plus() -> NSImage{
+    static func plus() -> NSImage {
         return NSImage(named: "SegmentIconPlus")!
     }
     
-    static func minus() -> NSImage{
+    static func minus() -> NSImage {
         return NSImage(named: "SegmentIconMinus")!
     }
     

--- a/Morphic/Morphic/MorphicBar/MorphicBarItemView.swift
+++ b/Morphic/Morphic/MorphicBar/MorphicBarItemView.swift
@@ -29,19 +29,19 @@ public class MorphicBarItemView: NSView {
     
     public var showsHelp: Bool = true
     
-    public override var isFlipped: Bool{
+    public override var isFlipped: Bool {
         return true
     }
     
 }
 
-class MorphicBarSegmentedButtonItemView: MorphicBarItemView{
+class MorphicBarSegmentedButtonItemView: MorphicBarItemView {
     
     var titleLabel: NSTextField
     var segmentedButton: MorphicBarSegmentedButton
     var titleButtonSpacing: CGFloat = 4.0
     
-    init(title: String, segments: [MorphicBarSegmentedButton.Segment]){
+    init(title: String, segments: [MorphicBarSegmentedButton.Segment]) {
         titleLabel = NSTextField(labelWithString: title)
         titleLabel.font = .morphicBold
         titleLabel.alignment = .center
@@ -52,14 +52,14 @@ class MorphicBarSegmentedButtonItemView: MorphicBarItemView{
         self.needsLayout = true
     }
     
-    override var showsHelp: Bool{
+    override var showsHelp: Bool {
         didSet{
             segmentedButton.showsHelp = showsHelp
         }
     }
     
-    private var titleYAdjustment: CGFloat{
-        guard let font = titleLabel.font else{
+    private var titleYAdjustment: CGFloat {
+        guard let font = titleLabel.font else {
             return 0.0
         }
         return ceil(font.capHeight - font.ascender)
@@ -77,7 +77,7 @@ class MorphicBarSegmentedButtonItemView: MorphicBarItemView{
         segmentedButton.frame = NSRect(origin: NSPoint(x: round((bounds.size.width - buttonSize.width) / 2), y: bounds.size.height - buttonSize.height), size: buttonSize)
     }
     
-    override var intrinsicContentSize: NSSize{
+    override var intrinsicContentSize: NSSize {
         let labelSize = titleLabel.intrinsicContentSize.roundedUp()
         let buttonSize = segmentedButton.intrinsicContentSize
         return NSSize(width: ceil(max(labelSize.width, buttonSize.width)), height: NSView.noIntrinsicMetric)

--- a/Morphic/Morphic/MorphicBar/MorphicBarSegmentedButton.swift
+++ b/Morphic/Morphic/MorphicBar/MorphicBarSegmentedButton.swift
@@ -38,7 +38,7 @@ class MorphicBarSegmentedButton: NSControl {
     
     // MARK: - Creating a Segmented Button
     
-    init(segments: [Segment]){
+    init(segments: [Segment]) {
         super.init(frame: NSRect(x: 0, y: 0, width: 100, height: 100))
         font = .morphicBold
         wantsLayer = true
@@ -70,7 +70,7 @@ class MorphicBarSegmentedButton: NSControl {
     // MARK: - Segments
     
     /// A segment's information
-    struct Segment{
+    struct Segment {
         
         /// The title to be shown on the segment, if any
         ///
@@ -92,7 +92,7 @@ class MorphicBarSegmentedButton: NSControl {
         var accessibilityLabel: String?
         
         /// Create a segment with a title
-        init(title: String, isPrimary: Bool, helpProvider: QuickHelpContentProvider?, accessibilityLabel: String?){
+        init(title: String, isPrimary: Bool, helpProvider: QuickHelpContentProvider?, accessibilityLabel: String?) {
             self.title = title
             self.helpProvider = helpProvider
             self.isPrimary = isPrimary
@@ -100,7 +100,7 @@ class MorphicBarSegmentedButton: NSControl {
         }
         
         /// Create a segment with an icon
-        init(icon: NSImage, isPrimary: Bool, helpProvider: QuickHelpContentProvider?, accessibilityLabel: String?){
+        init(icon: NSImage, isPrimary: Bool, helpProvider: QuickHelpContentProvider?, accessibilityLabel: String?) {
             self.icon = icon
             self.helpProvider = helpProvider
             self.isPrimary = isPrimary
@@ -109,7 +109,7 @@ class MorphicBarSegmentedButton: NSControl {
     }
     
     /// The segments on the control
-    var segments = [Segment](){
+    var segments = [Segment]() {
         didSet{
             updateButtons()
         }
@@ -117,23 +117,23 @@ class MorphicBarSegmentedButton: NSControl {
     
     // MARK: - Layout
     
-    override var isFlipped: Bool{
+    override var isFlipped: Bool {
         return true
     }
     
     /// Amount of inset each button segment should have
-    var contentInsets = NSEdgeInsets(top: 7, left: 9, bottom: 7, right: 9){
+    var contentInsets = NSEdgeInsets(top: 7, left: 9, bottom: 7, right: 9) {
         didSet{
             invalidateIntrinsicContentSize()
-            for button in segmentButtons{
+            for button in segmentButtons {
                 button.contentInsets = contentInsets
             }
         }
     }
     
-    override var intrinsicContentSize: NSSize{
+    override var intrinsicContentSize: NSSize {
         var size = NSSize(width: 0, height: contentInsets.top + contentInsets.bottom + 13)
-        for button in segmentButtons{
+        for button in segmentButtons {
             let buttonSize = button.intrinsicContentSize
             size.width += buttonSize.width
         }
@@ -153,7 +153,7 @@ class MorphicBarSegmentedButton: NSControl {
     // MARK: - Segment Buttons
     
     /// NSButton subclass that provides a custom intrinsic size with content insets
-    private class Button: NSButton{
+    private class Button: NSButton {
         
         private var boundsTrackingArea: NSTrackingArea!
         
@@ -166,21 +166,21 @@ class MorphicBarSegmentedButton: NSControl {
             return nil
         }
         
-        public var contentInsets = NSEdgeInsetsZero{
+        public var contentInsets = NSEdgeInsetsZero {
             didSet{
                 invalidateIntrinsicContentSize()
             }
         }
         
-        override var intrinsicContentSize: NSSize{
+        override var intrinsicContentSize: NSSize {
             var size = super.intrinsicContentSize.roundedUp()
             size.width += contentInsets.left + contentInsets.right
             size.height += contentInsets.top + contentInsets.bottom
             return size
         }
         
-        var showsHelp: Bool = true{
-            didSet{
+        var showsHelp: Bool = true {
+            didSet {
                 createBoundsTrackingArea()
             }
         }
@@ -196,15 +196,15 @@ class MorphicBarSegmentedButton: NSControl {
         }
         
         override func sendAction(_ action: Selector?, to target: Any?) -> Bool {
-            guard super.sendAction(action, to: target) else{
+            guard super.sendAction(action, to: target) else {
                 return false
             }
             updateHelpWindow()
             return true
         }
         
-        func updateHelpWindow(){
-            guard let viewController = helpProvider?.quickHelpViewController() else{
+        func updateHelpWindow() {
+            guard let viewController = helpProvider?.quickHelpViewController() else {
                 return
             }
             QuickHelpWindow.show(viewController: viewController)
@@ -215,11 +215,11 @@ class MorphicBarSegmentedButton: NSControl {
             createBoundsTrackingArea()
         }
         
-        private func createBoundsTrackingArea(){
-            if boundsTrackingArea != nil{
+        private func createBoundsTrackingArea() {
+            if boundsTrackingArea != nil {
                 removeTrackingArea(boundsTrackingArea)
             }
-            if showsHelp{
+            if showsHelp {
                 boundsTrackingArea = NSTrackingArea(rect: bounds, options: [.mouseEnteredAndExited, .activeAlways], owner: self, userInfo: nil)
                 addTrackingArea(boundsTrackingArea)
             }
@@ -227,9 +227,9 @@ class MorphicBarSegmentedButton: NSControl {
         
     }
     
-    public var showsHelp: Bool = true{
-        didSet{
-            for button in segmentButtons{
+    public var showsHelp: Bool = true {
+        didSet {
+            for button in segmentButtons {
                 button.showsHelp = showsHelp
             }
         }
@@ -239,11 +239,11 @@ class MorphicBarSegmentedButton: NSControl {
     private var segmentButtons = [Button]()
     
     /// Update the segment buttons
-    private func updateButtons(){
+    private func updateButtons() {
         setNeedsDisplay(bounds)
         invalidateIntrinsicContentSize()
         removeAllButtons()
-        for segment in segments{
+        for segment in segments {
             let button = self.createButton(for: segment)
             add(button: button)
         }
@@ -251,15 +251,15 @@ class MorphicBarSegmentedButton: NSControl {
     }
     
     /// Create a button for a segment
-    private func createButton(for segment: Segment) -> Button{
+    private func createButton(for segment: Segment) -> Button {
         let button = Button()
         button.bezelStyle = .regularSquare
         button.isBordered = false
         button.contentTintColor = titleColor
         button.contentInsets = contentInsets
-        if let title = segment.title{
+        if let title = segment.title {
             button.title = title
-        }else if let icon = segment.icon{
+        }else if let icon = segment.icon {
             button.image = icon
         }
         button.setAccessibilityLabel(segment.accessibilityLabel)
@@ -270,7 +270,7 @@ class MorphicBarSegmentedButton: NSControl {
     }
     
     /// Remove all buttons
-    private func removeAllButtons(){
+    private func removeAllButtons() {
         for i in (0..<segmentButtons.count).reversed(){
             removeButton(at: i)
         }
@@ -280,7 +280,7 @@ class MorphicBarSegmentedButton: NSControl {
     ///
     /// - parameters:
     ///   - index: The index of the button to remove
-    private func removeButton(at index: Int){
+    private func removeButton(at index: Int) {
         let button = segmentButtons[index]
         button.action = nil
         button.target = nil
@@ -292,7 +292,7 @@ class MorphicBarSegmentedButton: NSControl {
     ///
     /// - parameters:
     ///   - button: The button to add to the end of the list
-    private func add(button: Button){
+    private func add(button: Button) {
         let index = segmentButtons.count
         button.tag = index
         button.target = self
@@ -305,8 +305,8 @@ class MorphicBarSegmentedButton: NSControl {
     
     /// Handles a segment button click and calls this control's action
     @objc
-    private func segmentAction(_ sender: Any?){
-        guard let button = sender as? NSButton else{
+    private func segmentAction(_ sender: Any?) {
+        guard let button = sender as? NSButton else {
             return
         }
         integerValue = button.tag

--- a/Morphic/Morphic/MorphicBar/MorphicBarView.swift
+++ b/Morphic/Morphic/MorphicBar/MorphicBarView.swift
@@ -35,7 +35,7 @@ public class MorphicBarView: NSView {
     ///
     /// - parameters:
     ///   - itemView: The item view to add
-    public func add(itemView: MorphicBarItemView){
+    public func add(itemView: MorphicBarItemView) {
         itemViews.append(itemView)
         itemView.morphicBarView = self
         addSubview(itemView)
@@ -46,7 +46,7 @@ public class MorphicBarView: NSView {
     ///
     /// - parameters:
     ///   - index: The index of the item to remove
-    public func removeItemView(at index: Int){
+    public func removeItemView(at index: Int) {
         let itemView = itemViews[index]
         itemViews.remove(at: index)
         itemView.removeFromSuperview()
@@ -55,21 +55,21 @@ public class MorphicBarView: NSView {
     }
     
     /// Remove all item views from the MorphicBar
-    public func removeAllItemViews(){
-        for i in (0..<itemViews.count).reversed(){
+    public func removeAllItemViews() {
+        for i in (0..<itemViews.count).reversed() {
             removeItemView(at: i)
         }
     }
     
     // MARK: - Layout
     
-    public override var isFlipped: Bool{
+    public override var isFlipped: Bool {
         return true
     }
     
     public override func layout() {
         var frame = CGRect(x: 0, y: 0, width: 0, height: bounds.size.height)
-        for itemView in itemViews{
+        for itemView in itemViews {
             let size = itemView.intrinsicContentSize
             frame.size.width = size.width
             itemView.frame = frame
@@ -78,16 +78,16 @@ public class MorphicBarView: NSView {
     }
     
     /// The desired spacing between each item
-    public var itemSpacing: CGFloat = 18.0{
+    public var itemSpacing: CGFloat = 18.0 {
         didSet{
             needsLayout = true
             invalidateIntrinsicContentSize()
         }
     }
     
-    public override var intrinsicContentSize: NSSize{
+    public override var intrinsicContentSize: NSSize {
         var size = NSSize(width: itemSpacing * CGFloat(itemViews.count - 1), height: NSView.noIntrinsicMetric)
-        for itemView in itemViews{
+        for itemView in itemViews {
             let itemSize = itemView.intrinsicContentSize
             size.width += itemSize.width
         }
@@ -104,7 +104,7 @@ public class MorphicBarView: NSView {
 
 extension NSSize{
     
-    public func roundedUp() -> NSSize{
+    public func roundedUp() -> NSSize {
         return NSSize(width: ceil(width), height: ceil(height))
     }
     

--- a/Morphic/Morphic/MorphicBar/MorphicBarViewController.swift
+++ b/Morphic/Morphic/MorphicBar/MorphicBarViewController.swift
@@ -56,8 +56,8 @@ public class MorphicBarViewController: NSViewController {
     }
     
     @objc
-    func sessionUserDidChange(_ notification: NSNotification){
-        guard let session = notification.object as? Session else{
+    func sessionUserDidChange(_ notification: NSNotification) {
+        guard let session = notification.object as? Session else {
             return
         }
         self.logoutMenuItem?.isHidden = session.user == nil
@@ -75,7 +75,7 @@ public class MorphicBarViewController: NSViewController {
     
     /// Action to show the main menu from the logo button
     @IBAction
-    func showMainMenu(_ sender: Any?){
+    func showMainMenu(_ sender: Any?) {
         mainMenu.popUp(positioning: nil, at: NSPoint(x: logoButton.bounds.origin.x, y: logoButton.bounds.origin.y + logoButton.bounds.size.height), in: logoButton)
     }
     
@@ -85,12 +85,12 @@ public class MorphicBarViewController: NSViewController {
     @IBOutlet weak var morphicBarView: MorphicBarView!
     
     /// The items that should be shown on the MorphicBar
-    public var items = [MorphicBarItem](){
-        didSet{
+    public var items = [MorphicBarItem]() {
+        didSet {
             _ = view
             morphicBarView.removeAllItemViews()
             for item in items{
-                if let itemView = item.view(){
+                if let itemView = item.view() {
                     itemView.showsHelp = showsHelp
                     morphicBarView.add(itemView: itemView)
                 }
@@ -98,10 +98,10 @@ public class MorphicBarViewController: NSViewController {
         }
     }
     
-    var showsHelp: Bool = true{
-        didSet{
+    var showsHelp: Bool = true {
+        didSet {
             logoButton.showsHelp = showsHelp
-            for itemView in morphicBarView.itemViews{
+            for itemView in morphicBarView.itemViews {
                 itemView.showsHelp = showsHelp
             }
         }
@@ -109,7 +109,7 @@ public class MorphicBarViewController: NSViewController {
 
 }
 
-class LogoButton: NSButton{
+class LogoButton: NSButton {
     
     private var boundsTrackingArea: NSTrackingArea!
     
@@ -118,8 +118,8 @@ class LogoButton: NSButton{
         createBoundsTrackingArea()
     }
     
-    var showsHelp: Bool = true{
-        didSet{
+    var showsHelp: Bool = true {
+        didSet {
             createBoundsTrackingArea()
         }
     }
@@ -146,11 +146,11 @@ class LogoButton: NSButton{
         createBoundsTrackingArea()
     }
     
-    private func createBoundsTrackingArea(){
+    private func createBoundsTrackingArea() {
         if boundsTrackingArea != nil{
             removeTrackingArea(boundsTrackingArea)
         }
-        if showsHelp{
+        if showsHelp {
             boundsTrackingArea = NSTrackingArea(rect: bounds, options: [.mouseEnteredAndExited, .activeAlways], owner: self, userInfo: nil)
             addTrackingArea(boundsTrackingArea)
         }

--- a/Morphic/Morphic/MorphicBar/MorphicBarWindow.swift
+++ b/Morphic/Morphic/MorphicBar/MorphicBarWindow.swift
@@ -37,7 +37,7 @@ public class MorphicBarWindow: NSWindow {
     public var morphicBarViewController: MorphicBarViewController
     
     /// Create a new MorphicBar Window with a `MorphicBarViewController` as its `contentViewController`
-    public init(){
+    public init() {
         morphicBarViewController = MorphicBarViewController.init(nibName: nil, bundle: nil)
         super.init(contentRect: NSMakeRect(0, 0, 100, 100), styleMask: .borderless, backing: .buffered, defer: false)
         contentViewController = morphicBarViewController
@@ -47,7 +47,7 @@ public class MorphicBarWindow: NSWindow {
         backgroundColor = .clear
         isMovableByWindowBackground = true
         collectionBehavior = [.canJoinAllSpaces]
-        if let savedPosition = Position(rawValue: Session.shared.string(for: .morphicBarPosition) ?? ""){
+        if let savedPosition = Position(rawValue: Session.shared.string(for: .morphicBarPosition) ?? "") {
             position = savedPosition
         }
         setAccessibilityLabel("MorphicBar")
@@ -56,35 +56,35 @@ public class MorphicBarWindow: NSWindow {
     }
     
     @objc
-    func userDidChange(_ notification: NSNotification){
+    func userDidChange(_ notification: NSNotification) {
         updateMorphicBar()
     }
     
-    func updateMorphicBar(){
+    func updateMorphicBar() {
         morphicBarViewController.showsHelp = Session.shared.bool(for: .morphicBarShowsHelp) ?? true
-        if let preferredItems = Session.shared.array(for: .morphicBarItems){
+        if let preferredItems = Session.shared.array(for: .morphicBarItems) {
             morphicBarViewController.items = MorphicBarItem.items(from: preferredItems)
         }
         reposition(animated: false)
     }
     
-    public override var canBecomeKey: Bool{
+    public override var canBecomeKey: Bool {
         return true
     }
     
-    public override var canBecomeMain: Bool{
+    public override var canBecomeMain: Bool {
         return false
     }
     
     /// The allowed positions for the window
-    public enum Position: String{
+    public enum Position: String {
         case topLeft
         case topRight
         case bottomLeft
         case bottomRight
         
         /// Determine the origin for the given window at this position
-        fileprivate func origin(for window: MorphicBarWindow) -> NSPoint{
+        fileprivate func origin(for window: MorphicBarWindow) -> NSPoint {
             guard let screen = window.screen else{
                 return .zero
             }
@@ -102,7 +102,7 @@ public class MorphicBarWindow: NSWindow {
     }
     
     /// How far from the screen edges the window should position itself
-    public var screenInsets = NSEdgeInsets(top: 4, left: 4, bottom: 4, right: 4){
+    public var screenInsets = NSEdgeInsets(top: 4, left: 4, bottom: 4, right: 4) {
         didSet{
             reposition(animated: false)
         }
@@ -112,11 +112,11 @@ public class MorphicBarWindow: NSWindow {
     public private(set) var position: Position = .topRight
     
     /// Change the window's position, optionally animating the change
-    public func setPosition(_ position: Position, animated: Bool){
+    public func setPosition(_ position: Position, animated: Bool) {
         let changed = self.position != position
         self.position = position
         reposition(animated: animated)
-        if changed{
+        if changed {
             Session.shared.set(position.rawValue, for: .morphicBarPosition)
         }
     }
@@ -124,19 +124,19 @@ public class MorphicBarWindow: NSWindow {
     /// The nearst position to the window's current location
     ///
     /// Useful after a window has been moved by the user
-    private var nearestPosition: Position{
-        guard let area = screen?.visibleFrame else{
+    private var nearestPosition: Position {
+        guard let area = screen?.visibleFrame else {
             return position
         }
         let windowCenter = frame.center
         let areaCenter = area.center
-        if windowCenter.x < areaCenter.x{
-            if windowCenter.y < areaCenter.y{
+        if windowCenter.x < areaCenter.x {
+            if windowCenter.y < areaCenter.y {
                 return .bottomLeft
             }
             return .topLeft
-        }else{
-            if windowCenter.y < areaCenter.y{
+        } else {
+            if windowCenter.y < areaCenter.y {
                 return .bottomRight
             }
             return .topRight
@@ -144,7 +144,7 @@ public class MorphicBarWindow: NSWindow {
     }
     
     /// Move the window to its position
-    func reposition(animated: Bool){
+    func reposition(animated: Bool) {
         layoutIfNeeded()
         let origin = position.origin(for: self)
         let frame = NSRect(origin: origin, size: self.frame.size)
@@ -159,7 +159,7 @@ public class MorphicBarWindow: NSWindow {
 }
 
 /// Custom `NSView` that accepts first mouse to ensure proper window movement behavior
-class MorphicBarWindowContentView: NSView{
+class MorphicBarWindowContentView: NSView {
     
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
         // accept first mouse so the event propagates up to the window and we
@@ -168,16 +168,16 @@ class MorphicBarWindowContentView: NSView{
     }
 }
 
-private extension NSRect{
+private extension NSRect {
     
     /// The center point of the rectangle
-    var center: NSPoint{
+    var center: NSPoint {
         return NSPoint(x: origin.x + size.width / 2.0, y: origin.y + size.height / 2.0)
     }
     
 }
 
-public extension Preferences.Key{
+public extension Preferences.Key {
     
     /// The preference key that stores the position for the MorphicBar window on mac
     ///

--- a/Morphic/Morphic/Session.swift
+++ b/Morphic/Morphic/Session.swift
@@ -29,7 +29,7 @@ import MorphicService
 private let logger = OSLog(subsystem: "app", category: "Session")
 
 /// Extension to MorphicService.Session to create a shared session for the app
-extension Session{
+extension Session {
     
     static var shared: Session = {
         return Session(endpoint: Session.mainBundleEndpoint)
@@ -44,11 +44,11 @@ extension Session{
     /// URL is specified in `Debug.xcconfig`, each developer can override the setting by
     /// creating a `Local.xcconfig` with whatever value is relevant to their local setup.
     static var mainBundleEndpoint: URL! = {
-        guard let endpointString = Bundle.main.infoDictionary?["MorphicServiceEndpoint"] as? String else{
+        guard let endpointString = Bundle.main.infoDictionary?["MorphicServiceEndpoint"] as? String else {
             os_log(.fault, log: logger, "Missing morphic endpoint.  Check build config files")
             return nil
         }
-        guard let endpoint = URL(string: endpointString) else{
+        guard let endpoint = URL(string: endpointString) else {
             os_log(.fault, log: logger, "Invalid morphic endpoint.  Check build config files")
             return nil
         }
@@ -57,7 +57,7 @@ extension Session{
     
 }
 
-extension NSNotification.Name{
+extension NSNotification.Name {
     
     static let morphicSignin = NSNotification.Name("org.raisingthefloor.morphicSignin")
     

--- a/Morphic/Morphic/Theme.swift
+++ b/Morphic/Morphic/Theme.swift
@@ -32,7 +32,7 @@ private var lighterGreen = NSColor(srgbRed: 102.0/255.0, green: 181.0/255.0, blu
 /// The same dark blue found around the oustside of the Morphic logo
 private var darkBlue = NSColor(srgbRed: 0, green: 41.0/255.0, blue: 87.0/255.0, alpha: 1.0)
 
-extension NSColor{
+extension NSColor {
     
     /// The primary dark color to use for Morphic elements
     ///
@@ -51,7 +51,7 @@ extension NSColor{
     
 }
 
-extension NSFont{
+extension NSFont {
     
     static var morphicBold : NSFont = .systemFont(ofSize: 14.0, weight: .bold)
 }

--- a/Morphic/MorphicConfigurator/AppDelegate.swift
+++ b/Morphic/MorphicConfigurator/AppDelegate.swift
@@ -30,12 +30,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         populateSolutions()
         Session.shared.open {
-            for arg in ProcessInfo.processInfo.arguments[1...]{
-                if arg == "login"{
+            for arg in ProcessInfo.processInfo.arguments[1...] {
+                if arg == "login" {
                     self.showLoginWindow(nil)
                     break
                 }
-                if arg == "capture"{
+                if arg == "capture" {
                     self.showCaptureWindow(nil)
                     break
                 }
@@ -43,13 +43,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
     }
     
-    func populateSolutions(){
+    func populateSolutions() {
         Session.shared.settings.populateSolutions(fromResource: "macos.solutions")
     }
     
 //    func application(_ application: NSApplication, open urls: [URL]) {
-//        if let url = urls.first{
-//            switch url.path{
+//        if let url = urls.first {
+//            switch url.path {
 //            case "login":
 //                captureWindowController?.close()
 //                showLoginWindow(nil)
@@ -72,8 +72,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     
     var loginWindowController: NSWindowController?
     
-    func showLoginWindow(_ sender: Any?){
-        if loginWindowController == nil{
+    func showLoginWindow(_ sender: Any?) {
+        if loginWindowController == nil {
             loginWindowController = LoginWindowController(windowNibName: "LoginWindow")
         }
         loginWindowController?.window?.makeKeyAndOrderFront(sender)
@@ -82,8 +82,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     
     var captureWindowController: NSWindowController?
     
-    func showCaptureWindow(_ sender: Any?){
-        if captureWindowController == nil{
+    func showCaptureWindow(_ sender: Any?) {
+        if captureWindowController == nil {
             captureWindowController = CaptureWindowController(windowNibName: "CaptureWindow")
         }
         captureWindowController?.window?.makeKeyAndOrderFront(sender)
@@ -91,13 +91,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
     
     func windowWillClose(_ notification: Notification) {
-        guard let window = notification.object as? NSWindow else{
+        guard let window = notification.object as? NSWindow else {
             return
         }
-        if window == captureWindowController?.window{
+        if window == captureWindowController?.window {
             captureWindowController = nil
         }
-        if window == loginWindowController?.window{
+        if window == loginWindowController?.window {
             loginWindowController = nil
         }
     }

--- a/Morphic/MorphicConfigurator/Capture/CaptureViewController.swift
+++ b/Morphic/MorphicConfigurator/Capture/CaptureViewController.swift
@@ -1,17 +1,32 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  CaptureViewController.swift
-//  MorphicConfigurator
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by Owen Shaw on 6/24/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import Cocoa
 import MorphicCore
 import MorphicSettings
 import MorphicService
 
-protocol CaptureViewControllerDelegate: class{
+protocol CaptureViewControllerDelegate: class {
     
     func capture(_ viewController: CaptureViewController, didCapture preferences: Preferences)
 
@@ -48,7 +63,7 @@ class CaptureViewController: NSViewController {
         }
     }
     
-    func notifyDelegateIfFullyComplete(){
+    func notifyDelegateIfFullyComplete() {
         guard miniumTimeComplete && captureComplete else{
             return
         }
@@ -68,7 +83,7 @@ class CaptureViewController: NSViewController {
     
     var animation: CABasicAnimation!
     
-    func startAnimating(){
+    func startAnimating() {
         animation = CABasicAnimation(keyPath: "transform.rotation.z")
         animation.fromValue = 0
         animation.toValue = -CGFloat.pi * 2
@@ -77,14 +92,14 @@ class CaptureViewController: NSViewController {
         gearImage.layer?.add(animation, forKey: "spin")
     }
     
-    func stopAnimating(){
+    func stopAnimating() {
         gearImage.layer?.removeAnimation(forKey: "spin")
         animation = nil
     }
     
 }
 
-class ImageContainerView: NSView{
+class ImageContainerView: NSView {
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)

--- a/Morphic/MorphicConfigurator/Capture/CaptureWindowController.swift
+++ b/Morphic/MorphicConfigurator/Capture/CaptureWindowController.swift
@@ -1,10 +1,25 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  CaptureWindowController.swift
-//  MorphicConfigurator
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by Owen Shaw on 6/24/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import Cocoa
 import MorphicCore
@@ -21,21 +36,21 @@ class CaptureWindowController: NSWindowController, CaptureViewControllerDelegate
         showCapture(animated: false)
     }
     
-    func showCapture(animated: Bool){
+    func showCapture(animated: Bool) {
         let captureViewController = CaptureViewController(nibName: "CaptureViewController", bundle: nil)
         captureViewController.delegate = self
         pageViewController.show(viewController: captureViewController, animated: animated)
     }
     
     func capture(_ viewController: CaptureViewController, didCapture preferences: Preferences) {
-        if Session.shared.user == nil{
+        if Session.shared.user == nil {
             showCreateAccount(preferences: preferences, animated: true)
-        }else{
+        } else {
             showDone(animated: true)
         }
     }
     
-    func showCreateAccount(preferences: Preferences, animated: Bool){
+    func showCreateAccount(preferences: Preferences, animated: Bool) {
         let createAccountViewController = CreateAccountViewController(nibName: "CreateAccountViewController", bundle: nil)
         createAccountViewController.preferences = preferences
         createAccountViewController.delegate = self
@@ -46,7 +61,7 @@ class CaptureWindowController: NSWindowController, CaptureViewControllerDelegate
         showDone(animated: true)
     }
     
-    func showDone(animated: Bool){
+    func showDone(animated: Bool) {
         let doneViewController = DoneViewController(nibName: "DoneViewController", bundle: nil)
         pageViewController.show(viewController: doneViewController, animated: animated)
     }

--- a/Morphic/MorphicConfigurator/Capture/CreateAccountViewController.swift
+++ b/Morphic/MorphicConfigurator/Capture/CreateAccountViewController.swift
@@ -1,17 +1,32 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  CreateAccountViewController.swift
-//  MorphicConfigurator
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by Owen Shaw on 6/24/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import Cocoa
 import MorphicCore
 import MorphicSettings
 import MorphicService
 
-protocol CreateAccountViewControllerDelegate: class{
+protocol CreateAccountViewControllerDelegate: class {
     
     func createAccount(_ viewController: CreateAccountViewController, didCreate user: User)
 
@@ -32,20 +47,20 @@ class CreateAccountViewController: NSViewController, NSTextFieldDelegate, Presen
         super.viewDidLoad()
     }
     
-    func pageTransitionCompleted(){
+    func pageTransitionCompleted() {
         view.window?.makeFirstResponder(emailField)
     }
     
     @IBAction
-    func createAccount(_ sender: Any?){
+    func createAccount(_ sender: Any?) {
         hideError()
         setFieldsEnabled(false)
         var user = User(identifier: "")
         user.email = emailField.stringValue.trimmingCharacters(in: .whitespaces)
         let creds = UsernameCredentials(username: user.email!, password: passwordField.stringValue)
-        Session.shared.register(user: user, credentials: creds, preferences: preferences){
+        Session.shared.register(user: user, credentials: creds, preferences: preferences) {
             result in
-            switch result{
+            switch result {
             case .success(let auth):
                 DistributedNotificationCenter.default().postNotificationName(.morphicSignin, object: nil, userInfo: ["isRegister": true], deliverImmediately: true)
                 self.delegate?.createAccount(self, didCreate: auth.user)
@@ -76,10 +91,10 @@ class CreateAccountViewController: NSViewController, NSTextFieldDelegate, Presen
     
     func controlTextDidChange(_ obj: Notification) {
         updateValid()
-        guard let field = obj.object as? NSTextField else{
+        guard let field = obj.object as? NSTextField else {
             return
         }
-        if (field == passwordField || field == confirmPasswordField){
+        if (field == passwordField || field == confirmPasswordField) {
             if hasTypedBothPasswords{
                 updatePasswordMatch()
             }
@@ -93,27 +108,27 @@ class CreateAccountViewController: NSViewController, NSTextFieldDelegate, Presen
         guard let field = obj.object as? NSTextField else{
             return
         }
-        if field == passwordField || field == confirmPasswordField{
-            if passwordField.stringValue.count > 0 && confirmPasswordField.stringValue.count > 0{
+        if field == passwordField || field == confirmPasswordField {
+            if passwordField.stringValue.count > 0 && confirmPasswordField.stringValue.count > 0 {
                 hasTypedBothPasswords = true
                 updatePasswordMatch()
             }
         }
     }
     
-    func updatePasswordMatch(){
+    func updatePasswordMatch() {
         if passwordField.stringValue.count > 0 && confirmPasswordField.stringValue.count > 0 && passwordField.stringValue != confirmPasswordField.stringValue{
             showError(message: "Passwords do not match", pointingTo: confirmPasswordField)
-        }else{
+        } else {
             hideError()
         }
     }
     
-    func updateValid(){
+    func updateValid() {
         submitButton.isEnabled = emailField.stringValue.trimmingCharacters(in: .whitespaces).count > 0 && passwordField.stringValue.count > 0 && passwordField.stringValue == confirmPasswordField.stringValue
     }
     
-    func setFieldsEnabled(_ enabled: Bool){
+    func setFieldsEnabled(_ enabled: Bool) {
         emailField.isEnabled = enabled
         passwordField.isEnabled = enabled
         confirmPasswordField.isEnabled = enabled
@@ -122,12 +137,12 @@ class CreateAccountViewController: NSViewController, NSTextFieldDelegate, Presen
     
     @IBOutlet var errorViewController: CreateAccountErrorViewController!
     
-    func showError(message: String, pointingTo view: NSView){
+    func showError(message: String, pointingTo view: NSView) {
         errorViewController.errorText = message
         errorPopover.show(relativeTo: view.bounds, of: view, preferredEdge: .maxX)
     }
     
-    func hideError(){
+    func hideError() {
         if errorPopover.isShown{
             errorPopover.close()
         }
@@ -135,7 +150,7 @@ class CreateAccountViewController: NSViewController, NSTextFieldDelegate, Presen
     
 }
 
-class CreateAccountErrorViewController: NSViewController{
+class CreateAccountErrorViewController: NSViewController {
     
     @IBOutlet weak var errorLabel: NSTextField!
     
@@ -144,8 +159,8 @@ class CreateAccountErrorViewController: NSViewController{
         errorLabel.stringValue = errorText ?? ""
     }
     
-    var errorText: String?{
-        didSet{
+    var errorText: String? {
+        didSet {
             errorLabel?.stringValue = errorText ?? ""
         }
     }

--- a/Morphic/MorphicConfigurator/Capture/DoneViewController.swift
+++ b/Morphic/MorphicConfigurator/Capture/DoneViewController.swift
@@ -1,10 +1,25 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  DoneViewController.swift
-//  MorphicConfigurator
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by Owen Shaw on 6/24/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import Cocoa
 import MorphicCore
@@ -14,9 +29,9 @@ class DoneViewController: NSViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        if let email = Session.shared.user?.email{
+        if let email = Session.shared.user?.email {
             emailLabel.stringValue = email
-        }else{
+        } else {
             emailLabel.isHidden = true
             emailIntroLabel.isHidden = true
         }
@@ -26,7 +41,7 @@ class DoneViewController: NSViewController {
     @IBOutlet weak var emailIntroLabel: NSTextField!
     
     @IBAction
-    func done(_ sender: Any?){
+    func done(_ sender: Any?) {
         NSApplication.shared.terminate(nil)
     }
 }

--- a/Morphic/MorphicConfigurator/Capture/PageViewController.swift
+++ b/Morphic/MorphicConfigurator/Capture/PageViewController.swift
@@ -1,10 +1,25 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  PageViewController.swift
-//  MorphicConfigurator
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by Owen Shaw on 6/24/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import Cocoa
 
@@ -14,7 +29,7 @@ class PageViewController: NSViewController {
         super.viewDidLoad()
     }
     
-    func show(viewController: NSViewController, animated: Bool){
+    func show(viewController: NSViewController, animated: Bool) {
         let shown = children.first
         shown?.removeFromParent()
         addChild(viewController)
@@ -22,11 +37,11 @@ class PageViewController: NSViewController {
         view.addSubview(viewController.view)
         let completion = {
             shown?.view.removeFromSuperview()
-            if let presentedViewController = viewController as? PresentedPageViewController{
+            if let presentedViewController = viewController as? PresentedPageViewController {
                 presentedViewController.pageTransitionCompleted()
             }
         }
-        if animated{
+        if animated {
             let dismissing = shown?.view
             let presenting = viewController.view
             presenting.frame = NSRect(origin: NSPoint(x: self.view.bounds.width, y: 0), size: view.bounds.size)
@@ -37,14 +52,14 @@ class PageViewController: NSViewController {
                 dismissing?.animator().frame = NSRect(origin: NSPoint(x: -self.view.bounds.width, y: 0), size: self.view.bounds.size)
                 dismissing?.animator().alphaValue = 0.0
             }, completionHandler: completion)
-        }else{
+        } else {
             completion()
         }
     }
     
 }
 
-protocol PresentedPageViewController{
+protocol PresentedPageViewController {
     
     func pageTransitionCompleted()
     

--- a/Morphic/MorphicConfigurator/Login/CustomCursorButton.swift
+++ b/Morphic/MorphicConfigurator/Login/CustomCursorButton.swift
@@ -1,25 +1,40 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  CustomCursorButton.swift
-//  MorphicConfigurator
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by Owen Shaw on 7/4/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import Cocoa
 
 class CustomCursorButton: NSButton {
 
-    public var cursor: NSCursor?{
+    public var cursor: NSCursor? {
         didSet{
             window?.invalidateCursorRects(for: self)
         }
     }
     
     override func resetCursorRects() {
-        if let cursor = cursor{
+        if let cursor = cursor {
             addCursorRect(bounds, cursor: cursor)
-        }else{
+        } else {
             super.resetCursorRects()
         }
     }

--- a/Morphic/MorphicConfigurator/Login/LoginWindowController.swift
+++ b/Morphic/MorphicConfigurator/Login/LoginWindowController.swift
@@ -1,10 +1,25 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  LoginWindowController.swift
-//  MorphicConfigurator
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by Owen Shaw on 6/24/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import Cocoa
 import MorphicCore
@@ -28,13 +43,13 @@ class LoginWindowController: NSWindowController, NSTextFieldDelegate {
     @IBOutlet weak var forgotPasswordButton: CustomCursorButton!
     
     @IBAction
-    func login(_ sender: Any?){
+    func login(_ sender: Any?) {
         errorLabel.isHidden = true
         setFieldsEnabled(false)
         let creds = UsernameCredentials(username: usernameField.stringValue, password: passwordField.stringValue)
-        _ = Session.shared.authenticate(usingUsername: creds){
+        _ = Session.shared.authenticate(usingUsername: creds) {
             success in
-            guard success else{
+            guard success else {
                 self.setFieldsEnabled(true)
                 self.errorLabel.isHidden = false
                 return
@@ -46,8 +61,8 @@ class LoginWindowController: NSWindowController, NSTextFieldDelegate {
     }
     
     @IBAction
-    func forgotPassword(_ sender: Any?){
-        guard let urlString = Bundle.main.infoDictionary?["FrontEndURL"] as? String else{
+    func forgotPassword(_ sender: Any?) {
+        guard let urlString = Bundle.main.infoDictionary?["FrontEndURL"] as? String else {
             return
         }
         let url = URL(string: urlString)!.appendingPathComponent("password").appendingPathComponent("reset")
@@ -58,23 +73,23 @@ class LoginWindowController: NSWindowController, NSTextFieldDelegate {
         updateValid()
     }
     
-    func setFieldsEnabled(_ enabled: Bool){
+    func setFieldsEnabled(_ enabled: Bool) {
         usernameField.isEnabled = enabled
         passwordField.isEnabled = enabled
         submitButton.isEnabled = enabled
     }
     
-    func indicateActivity(withStatusText text: String?){
+    func indicateActivity(withStatusText text: String?) {
         statusLabel.isHidden = false
         statusLabel.stringValue = text ?? ""
         activityIndicator.startAnimation(nil)
     }
     
-    func updateValid(){
+    func updateValid() {
         submitButton.isEnabled = usernameField.stringValue.trimmingCharacters(in: .whitespaces).count > 0 && passwordField.stringValue.count > 0
     }
     
-    func stopActivity(){
+    func stopActivity() {
         statusLabel.isHidden = true
         activityIndicator.stopAnimation(nil)
     }

--- a/Morphic/MorphicConfiguratorTests/MorphicConfiguratorTests.swift
+++ b/Morphic/MorphicConfiguratorTests/MorphicConfiguratorTests.swift
@@ -1,10 +1,25 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  MorphicConfiguratorTests.swift
-//  MorphicConfiguratorTests
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by Owen Shaw on 4/13/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import XCTest
 @testable import MorphicConfigurator

--- a/Morphic/MorphicConfiguratorUITests/MorphicConfiguratorUITests.swift
+++ b/Morphic/MorphicConfiguratorUITests/MorphicConfiguratorUITests.swift
@@ -1,10 +1,25 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  MorphicConfiguratorUITests.swift
-//  MorphicConfiguratorUITests
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by Owen Shaw on 4/13/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import XCTest
 

--- a/Morphic/MorphicTests/MorphicTests.swift
+++ b/Morphic/MorphicTests/MorphicTests.swift
@@ -1,10 +1,25 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  MorphicTests.swift
-//  MorphicTests
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by Owen Shaw on 4/13/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import XCTest
 @testable import Morphic

--- a/Morphic/MorphicUITests/MorphicUITests.swift
+++ b/Morphic/MorphicUITests/MorphicUITests.swift
@@ -1,10 +1,25 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  MorphicUITests.swift
-//  MorphicUITests
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by Owen Shaw on 4/13/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import XCTest
 

--- a/MorphicCore/MorphicCore/Codable+Morphic.swift
+++ b/MorphicCore/MorphicCore/Codable+Morphic.swift
@@ -23,9 +23,8 @@
 
 import Foundation
 
-
 /// Protocol for interoperable types, like those that can be contained in a JSON file
-public protocol Interoperable{
+public protocol Interoperable {
     
     /// Encode this value into a keyed container under the given key
     func encode(to keyedContainer: inout KeyedEncodingContainer<ArbitraryKeys>, for key: ArbitraryKeys) throws
@@ -35,7 +34,7 @@ public protocol Interoperable{
     
 }
 
-extension Int: Interoperable{
+extension Int: Interoperable {
 
     public func encode(to keyedContainer: inout KeyedEncodingContainer<ArbitraryKeys>, for key: ArbitraryKeys) throws {
         try keyedContainer.encode(self, forKey: key)
@@ -46,19 +45,7 @@ extension Int: Interoperable{
     }
 }
 
-extension Double: Interoperable{
-
-    public func encode(to keyedContainer: inout KeyedEncodingContainer<ArbitraryKeys>, for key: ArbitraryKeys) throws {
-        try keyedContainer.encode(self, forKey: key)
-    }
-    
-    public func encode(to unkeyedContainer: inout UnkeyedEncodingContainer) throws {
-        try unkeyedContainer.encode(self)
-    }
-    
-}
-
-extension Bool: Interoperable{
+extension Double: Interoperable {
 
     public func encode(to keyedContainer: inout KeyedEncodingContainer<ArbitraryKeys>, for key: ArbitraryKeys) throws {
         try keyedContainer.encode(self, forKey: key)
@@ -70,7 +57,7 @@ extension Bool: Interoperable{
     
 }
 
-extension String: Interoperable{
+extension Bool: Interoperable {
 
     public func encode(to keyedContainer: inout KeyedEncodingContainer<ArbitraryKeys>, for key: ArbitraryKeys) throws {
         try keyedContainer.encode(self, forKey: key)
@@ -82,7 +69,19 @@ extension String: Interoperable{
     
 }
 
-extension Array : Interoperable where Element == Interoperable?{
+extension String: Interoperable {
+
+    public func encode(to keyedContainer: inout KeyedEncodingContainer<ArbitraryKeys>, for key: ArbitraryKeys) throws {
+        try keyedContainer.encode(self, forKey: key)
+    }
+    
+    public func encode(to unkeyedContainer: inout UnkeyedEncodingContainer) throws {
+        try unkeyedContainer.encode(self)
+    }
+    
+}
+
+extension Array: Interoperable where Element == Interoperable? {
     
     public func encode(to keyedContainer: inout KeyedEncodingContainer<ArbitraryKeys>, for key: ArbitraryKeys) throws {
         var nestedContainer = keyedContainer.nestedUnkeyedContainer(forKey: key)
@@ -95,69 +94,69 @@ extension Array : Interoperable where Element == Interoperable?{
     }
     
     /// Encode this arrays's interoperable elements into a keyed container
-    public func encodeElements(to unkeyedContainer: inout UnkeyedEncodingContainer) throws{
-        for v in self{
-            if let v = v{
+    public func encodeElements(to unkeyedContainer: inout UnkeyedEncodingContainer) throws {
+        for v in self {
+            if let v = v {
                 try v.encode(to: &unkeyedContainer)
-            }else{
+            } else {
                 try unkeyedContainer.encodeNil()
             }
         }
     }
     
     /// Get the integer value at the given index
-    public func int(at index: Int) -> Int?{
+    public func int(at index: Int) -> Int? {
         return self[index] as? Int
     }
     
     /// Set the integer value at the given index
-    public mutating func set(_ int: Int, at index: Int){
+    public mutating func set(_ int: Int, at index: Int) {
         self[index] = int
     }
     
     /// Get the double value at the given index
-    public func double(at index: Int) -> Double?{
+    public func double(at index: Int) -> Double? {
         return self[index] as? Double
     }
     
     /// Set the double value at the given index
-    public mutating func set(_ double: Double, at index: Int){
+    public mutating func set(_ double: Double, at index: Int) {
         self[index] = double
     }
     
     /// Get the string value at the given index
-    public func string(at index: Int) -> String?{
+    public func string(at index: Int) -> String? {
         return self[index] as? String
     }
     
     /// Set the string value at the given index
-    public mutating func set(_ string: String, at index: Int){
+    public mutating func set(_ string: String, at index: Int) {
         self[index] = string
     }
     
     /// Get the bool value at the given index
-    public func bool(at index: Int) -> Bool?{
+    public func bool(at index: Int) -> Bool? {
         return self[index] as? Bool
     }
     
     /// Set the bool value at the given index
-    public mutating func set(_ bool: Bool, at index: Int){
+    public mutating func set(_ bool: Bool, at index: Int) {
         self[index] = bool
     }
     
     /// Get the nested array at the given index
-    public func array(at index: Int) -> [Interoperable?]?{
+    public func array(at index: Int) -> [Interoperable?]? {
         return self[index] as? [Interoperable?]
     }
     
     /// Get the dictionary at the given index
-    public func dictionary(at index: Int) -> [String: Interoperable?]?{
+    public func dictionary(at index: Int) -> [String: Interoperable?]? {
         return self[index] as? [String: Interoperable?]
     }
     
 }
 
-extension Dictionary: Interoperable where Key == String, Value == Interoperable?{
+extension Dictionary: Interoperable where Key == String, Value == Interoperable? {
 
     public func encode(to keyedContainer: inout KeyedEncodingContainer<ArbitraryKeys>, for key: ArbitraryKeys) throws {
         var nestedContainer = keyedContainer.nestedContainer(keyedBy: ArbitraryKeys.self, forKey: key)
@@ -170,70 +169,70 @@ extension Dictionary: Interoperable where Key == String, Value == Interoperable?
     }
     
     /// Encode this dictionary's interoperable elements into a keyed container
-    public func encodeElements(to keyedContainer: inout KeyedEncodingContainer<ArbitraryKeys>) throws{
-        for (k,v) in self{
+    public func encodeElements(to keyedContainer: inout KeyedEncodingContainer<ArbitraryKeys>) throws {
+        for (k,v) in self {
             let key = ArbitraryKeys(stringValue: k)!
-            if let v = v{
+            if let v = v {
                 try v.encode(to: &keyedContainer, for: key)
-            }else{
+            } else {
                 try keyedContainer.encodeNil(forKey: key)
             }
         }
     }
     
     /// Get the integer value for the given key
-    public func int(for key: String) -> Int?{
+    public func int(for key: String) -> Int? {
         return self[key] as? Int
     }
     
     /// Set the integer value for the given key
-    public mutating func set(_ int: Int, for key: String){
+    public mutating func set(_ int: Int, for key: String) {
         self[key] = int
     }
     
     /// Get the double value for the given key
-    public func double(for key: String) -> Double?{
+    public func double(for key: String) -> Double? {
         return self[key] as? Double
     }
     
     /// Set the double value for the given key
-    public mutating func set(_ double: Double, for key: String){
+    public mutating func set(_ double: Double, for key: String) {
         self[key] = double
     }
     
     /// Get the string value for the given key
-    public func string(for key: String) -> String?{
+    public func string(for key: String) -> String? {
         return self[key] as? String
     }
     
     /// Set the string value for the given key
-    public mutating func set(_ string: String, for key: String){
+    public mutating func set(_ string: String, for key: String) {
         self[key] = string
     }
     
     /// Get the bool value for the given key
-    public func bool(for key: String) -> Bool?{
+    public func bool(for key: String) -> Bool? {
         return self[key] as? Bool
     }
     
     /// Set the bool value for the given key
-    public mutating func set(_ bool: Bool, for key: String){
+    public mutating func set(_ bool: Bool, for key: String) {
         self[key] = bool
     }
     
     /// Get the array for the given key
-    public func array(for key: String) -> [Interoperable?]?{
+    public func array(for key: String) -> [Interoperable?]? {
         return self[key] as? [Interoperable?]
     }
     
     /// Get the nested dictionar for the given key
-    public func dictionary(for key: String) -> [String: Interoperable?]?{
+    public func dictionary(for key: String) -> [String: Interoperable?]? {
         return self[key] as? [String: Interoperable?]
     }
 }
 
 /// Support any key in a container
-public class ArbitraryKeys: CodingKey{
+public class ArbitraryKeys: CodingKey {
     
     required public init?(intValue: Int) {
         self.stringValue = String(intValue)
@@ -255,35 +254,35 @@ public class ArbitraryKeys: CodingKey{
 public extension KeyedDecodingContainer{
     
     /// Decode an dictionary of `Interoperable`s in arbitrary keys
-    func decodeInteroperableDictionary() throws -> [String: Interoperable?]{
+    func decodeInteroperableDictionary() throws -> [String: Interoperable?] {
         var dict = [String: Interoperable?]()
-        for key in allKeys{
+        for key in allKeys {
             try dict[key.stringValue] = decodeInteroperable(for: key)
         }
         return dict
     }
     
     /// Decode an `Interoperable` for the given key
-    func decodeInteroperable(for key: Key) throws -> Interoperable?{
-        if (try? decodeNil(forKey: key)) ?? false{
+    func decodeInteroperable(for key: Key) throws -> Interoperable? {
+        if (try? decodeNil(forKey: key)) ?? false {
             return nil
         }
-        if let i = try? decode(Int.self, forKey: key){
+        if let i = try? decode(Int.self, forKey: key) {
             return i
         }
-        if let d = try? decode(Double.self, forKey: key){
+        if let d = try? decode(Double.self, forKey: key) {
             return d
         }
-        if let b = try? decode(Bool.self, forKey: key){
+        if let b = try? decode(Bool.self, forKey: key) {
             return b
         }
-        if let s = try? decode(String.self, forKey: key){
+        if let s = try? decode(String.self, forKey: key) {
             return s
         }
-        if var container = try? nestedUnkeyedContainer(forKey: key){
+        if var container = try? nestedUnkeyedContainer(forKey: key) {
             return try container.decodeInteroperableArray()
         }
-        if let container = try? nestedContainer(keyedBy: Key.self, forKey: key){
+        if let container = try? nestedContainer(keyedBy: Key.self, forKey: key) {
             return try container.decodeInteroperableDictionary()
         }
         throw ArbitraryKeys.ValueError.typeNotFound
@@ -294,38 +293,38 @@ public extension KeyedDecodingContainer{
 public extension UnkeyedDecodingContainer{
     
     /// Decode an array of `Interoperable`s
-    mutating func decodeInteroperableArray() throws -> [Interoperable?]{
-        guard let count = count else{
+    mutating func decodeInteroperableArray() throws -> [Interoperable?] {
+        guard let count = count else {
             return []
         }
         var array = [Interoperable?]()
-        for _ in 0..<count{
+        for _ in 0..<count {
             try array.append(decodeInteroperable())
         }
         return array
     }
     
     /// Decode an `Interoperable`
-    mutating func decodeInteroperable() throws -> Interoperable?{
-        if (try? decodeNil()) ?? false{
+    mutating func decodeInteroperable() throws -> Interoperable? {
+        if (try? decodeNil()) ?? false {
             return nil
         }
-        if let i = try? decode(Int.self){
+        if let i = try? decode(Int.self) {
             return i
         }
-        if let d = try? decode(Double.self){
+        if let d = try? decode(Double.self) {
             return d
         }
-        if let b = try? decode(Bool.self){
+        if let b = try? decode(Bool.self) {
             return b
         }
-        if let s = try? decode(String.self){
+        if let s = try? decode(String.self) {
             return s
         }
-        if var container = try? nestedUnkeyedContainer(){
+        if var container = try? nestedUnkeyedContainer() {
             return try container.decodeInteroperableArray()
         }
-        if let container = try? nestedContainer(keyedBy: ArbitraryKeys.self){
+        if let container = try? nestedContainer(keyedBy: ArbitraryKeys.self) {
             return try container.decodeInteroperableDictionary()
         }
         throw ArbitraryKeys.ValueError.typeNotFound

--- a/MorphicCore/MorphicCore/Credentials.swift
+++ b/MorphicCore/MorphicCore/Credentials.swift
@@ -24,24 +24,24 @@
 import Foundation
 
 /// Morphic authentication credentials
-public protocol Credentials{
+public protocol Credentials {
 }
 
 /// Secret key based credentials
-public struct KeyCredentials: Credentials{
+public struct KeyCredentials: Credentials {
     public var key: String
     
-    public init(key: String){
+    public init(key: String) {
         self.key = key
     }
 }
 
 /// Username/password credentials
-public struct UsernameCredentials: Credentials{
+public struct UsernameCredentials: Credentials {
     public var username: String
     public var password: String
     
-    public init(username: String, password: String){
+    public init(username: String, password: String) {
         self.username = username
         self.password = password
     }

--- a/MorphicCore/MorphicCore/Keychain.swift
+++ b/MorphicCore/MorphicCore/Keychain.swift
@@ -28,10 +28,10 @@ import OSLog
 private let logger = OSLog(subsystem: "MorphicCore", category: "Keychain")
 
 /// Simpler interface to SECKeychain functionality for secure password/secret storage
-public class Keychain{
+public class Keychain {
     
     /// Create a keychain with the given identifier
-    public init(identifier: String){
+    public init(identifier: String) {
         self.identifier = identifier
     }
     
@@ -46,33 +46,33 @@ public class Keychain{
     // MARK: - Username/Password Logins
     
     /// Get a website login item
-    public func usernameCredentials(for url: URL, username: String) -> UsernameCredentials?{
+    public func usernameCredentials(for url: URL, username: String) -> UsernameCredentials? {
         let query = identifyingAttributes(for: url, username: username)
-        guard let result = first(matching: query) else{
+        guard let result = first(matching: query) else {
             return nil
         }
-        guard let username = result.string(for: kSecAttrAccount) else{
+        guard let username = result.string(for: kSecAttrAccount) else {
             return nil
         }
-        guard let password = result.string(for: kSecValueData, encoding: .utf8) else{
+        guard let password = result.string(for: kSecValueData, encoding: .utf8) else {
             return nil
         }
         return UsernameCredentials(username: username, password: password)
     }
     
-    public func save(usernameCredentials: UsernameCredentials, for url: URL) -> Bool{
+    public func save(usernameCredentials: UsernameCredentials, for url: URL) -> Bool {
         let query = identifyingAttributes(for: url, username: usernameCredentials.username)
         var attributes = query
         attributes[kSecValueData] = usernameCredentials.password.data(using: .utf8)! as CFData
         return save(attributes: attributes, matching: query)
     }
     
-    public func removeUsernameCredentials(for url: URL, username: String) -> Bool{
+    public func removeUsernameCredentials(for url: URL, username: String) -> Bool {
         let query = identifyingAttributes(for: url, username: username)
         return remove(matching: query)
     }
     
-    private func identifyingAttributes(for url: URL, username: String) -> [CFString: CFTypeRef]{
+    private func identifyingAttributes(for url: URL, username: String) -> [CFString: CFTypeRef] {
         var attributes: [CFString: CFTypeRef] = [
             kSecClass: kSecClassInternetPassword,
             kSecAttrAccessGroup: identifier as CFString,
@@ -84,32 +84,32 @@ public class Keychain{
     
     // MARK: - Secret Key Logins
     
-    public func keyCredentials(for url: URL, userIdentifier: String) -> KeyCredentials?{
+    public func keyCredentials(for url: URL, userIdentifier: String) -> KeyCredentials? {
         let query = identifyingAttributes(for: url, service: secretKeyService, userIdentifier: userIdentifier)
-        guard let result = first(matching: query) else{
+        guard let result = first(matching: query) else {
             return nil
         }
-        guard let key = result.string(for: kSecValueData, encoding: .utf8) else{
+        guard let key = result.string(for: kSecValueData, encoding: .utf8) else {
             return nil
         }
         return KeyCredentials(key: key)
     }
     
-    public func save(keyCredentials: KeyCredentials, for url: URL, userIdentifier: String) -> Bool{
+    public func save(keyCredentials: KeyCredentials, for url: URL, userIdentifier: String) -> Bool {
         let query = identifyingAttributes(for: url, service: secretKeyService, userIdentifier: userIdentifier)
         var attributes = query
         attributes[kSecValueData] = keyCredentials.key.data(using: .utf8)! as CFData
         return save(attributes: attributes, matching: query)
     }
     
-    public func removeKeyCredentials(for url: URL, userIdentifier: String) -> Bool{
+    public func removeKeyCredentials(for url: URL, userIdentifier: String) -> Bool {
         let query = identifyingAttributes(for: url, service: secretKeyService, userIdentifier: userIdentifier)
         return remove(matching: query)
     }
     
     private var secretKeyService = "org.raisingthefloor.morphic.secret-key"
     
-    private func identifyingAttributes(for url: URL, service: String, userIdentifier: String) -> [CFString: CFTypeRef]{
+    private func identifyingAttributes(for url: URL, service: String, userIdentifier: String) -> [CFString: CFTypeRef] {
         return [
             kSecClass: kSecClassGenericPassword,
             kSecAttrAccessGroup: identifier as CFString,
@@ -121,7 +121,7 @@ public class Keychain{
     
     // MARK: - Auth Tokens
     
-    public func authToken(for url: URL, userIdentifier: String) -> String?{
+    public func authToken(for url: URL, userIdentifier: String) -> String? {
         let query = identifyingAttributes(for: url, service: authTokenService, userIdentifier: userIdentifier)
         guard let result = first(matching: query) else{
             return nil
@@ -132,14 +132,14 @@ public class Keychain{
         return token
     }
     
-    public func save(authToken: String, for url: URL, userIdentifier: String) -> Bool{
+    public func save(authToken: String, for url: URL, userIdentifier: String) -> Bool {
         let query = identifyingAttributes(for: url, service: authTokenService, userIdentifier: userIdentifier)
         var attributes = query
         attributes[kSecValueData] = authToken.data(using: .utf8)! as CFData
         return save(attributes: attributes, matching: query)
     }
     
-    public func removeAuthToken(for url: URL, userIdentifier: String) -> Bool{
+    public func removeAuthToken(for url: URL, userIdentifier: String) -> Bool {
         let query = identifyingAttributes(for: url, service: authTokenService, userIdentifier: userIdentifier)
         return remove(matching: query)
     }
@@ -148,7 +148,7 @@ public class Keychain{
     
     // MARK: - Querying
     
-    private func first(matching query: [CFString: CFTypeRef]) -> [CFString: CFTypeRef]?{
+    private func first(matching query: [CFString: CFTypeRef]) -> [CFString: CFTypeRef]? {
         var query = query
         query[kSecUseDataProtectionKeychain] = kCFBooleanTrue
         query[kSecReturnData] = kCFBooleanTrue
@@ -156,18 +156,18 @@ public class Keychain{
         query[kSecMatchLimit] = kSecMatchLimitOne
         let result = UnsafeMutablePointer<CFTypeRef?>.allocate(capacity: 1)
         let status = SecItemCopyMatching(query as CFDictionary, result)
-        guard status == errSecSuccess else{
+        guard status == errSecSuccess else {
             if status != errSecItemNotFound{
                 os_log(.error, log: logger, "Failed to query item in keychain: %d", status)
             }
             result.deallocate()
             return nil
         }
-        guard let pointee = result.pointee else{
+        guard let pointee = result.pointee else {
             result.deallocate()
             return nil
         }
-        guard let resultAttributes = pointee as! CFDictionary as? [CFString: CFTypeRef] else{
+        guard let resultAttributes = pointee as! CFDictionary as? [CFString: CFTypeRef] else {
             result.deallocate()
             return nil
         }
@@ -175,32 +175,32 @@ public class Keychain{
         return resultAttributes
     }
     
-    private func save(attributes: [CFString: CFTypeRef], matching query: [CFString: CFTypeRef]) -> Bool{
+    private func save(attributes: [CFString: CFTypeRef], matching query: [CFString: CFTypeRef]) -> Bool {
         var attributes = attributes
         attributes[kSecUseDataProtectionKeychain] = kCFBooleanTrue
         attributes[kSecAttrSynchronizable] = kCFBooleanFalse
         attributes[kSecAttrIsInvisible] = kCFBooleanFalse
         attributes[kSecAttrModificationDate] = NSDate.now as CFDate
         var status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
-        if status == errSecItemNotFound{
+        if status == errSecItemNotFound {
             attributes[kSecAttrCreationDate] = attributes[kSecAttrModificationDate]
             status = SecItemAdd(attributes as CFDictionary, nil)
-            if status != errSecSuccess{
+            if status != errSecSuccess {
                 os_log(.error, log: logger, "Failed to add item to keychain: %d", status)
                 return false
             }
             return true
         }
-        if status != errSecSuccess{
+        if status != errSecSuccess {
             os_log(.error, log: logger, "Failed to update item in keychain: %d", status)
             return false
         }
         return true
     }
     
-    private func remove(matching query: [CFString: CFTypeRef]) -> Bool{
+    private func remove(matching query: [CFString: CFTypeRef]) -> Bool {
         let status = SecItemDelete(query as CFDictionary)
-        if status != errSecSuccess{
+        if status != errSecSuccess {
             os_log(.error, log: logger, "Failed to remove item from keychain: %d", status)
             return false
         }
@@ -209,41 +209,41 @@ public class Keychain{
     
 }
 
-fileprivate extension Dictionary where Key: CFString, Value: CFTypeRef{
+fileprivate extension Dictionary where Key: CFString, Value: CFTypeRef {
     
-    func string(for key: Key) -> String?{
-        guard let value = self[key] else{
+    func string(for key: Key) -> String? {
+        guard let value = self[key] else {
             return nil
         }
         return value as! CFString as String
     }
     
-    func string(for key: Key, encoding: String.Encoding) -> String?{
-        guard let data = data(for: key) else{
+    func string(for key: Key, encoding: String.Encoding) -> String? {
+        guard let data = data(for: key) else {
             return nil
         }
         return String(data: data, encoding: encoding)
     }
     
-    func data(for key: Key) -> Data?{
-        guard let value = self[key] else{
+    func data(for key: Key) -> Data? {
+        guard let value = self[key] else {
             return nil
         }
         return value as! CFData as Data
     }
     
-    func number(for key: Key) -> NSNumber?{
-        guard let value = self[key] else{
+    func number(for key: Key) -> NSNumber? {
+        guard let value = self[key] else {
             return nil
         }
         return value as! CFNumber as NSNumber
     }
     
-    func int(for key: Key) -> Int?{
+    func int(for key: Key) -> Int? {
         return number(for: key)?.intValue
     }
     
-    mutating func merge(_ other: [Key: Value]){
+    mutating func merge(_ other: [Key: Value]) {
         for (k,v) in other{
             self[k] = v
         }
@@ -253,22 +253,22 @@ fileprivate extension Dictionary where Key: CFString, Value: CFTypeRef{
 
 fileprivate extension URL{
     
-    static func from(keychainAttributes: [CFString : CFTypeRef]) -> URL?{
+    static func from(keychainAttributes: [CFString : CFTypeRef]) -> URL? {
         var components = URLComponents()
-        if let proto = keychainAttributes.string(for: kSecAttrProtocol){
-            if proto == kSecAttrProtocolHTTP as String{
+        if let proto = keychainAttributes.string(for: kSecAttrProtocol) {
+            if proto == kSecAttrProtocolHTTP as String {
                 components.scheme = "http"
-            }else if proto == kSecAttrProtocolHTTPS as String{
+            }else if proto == kSecAttrProtocolHTTPS as String {
                 components.scheme = "https"
             }
         }
-        if let host = keychainAttributes.string(for: kSecAttrServer){
+        if let host = keychainAttributes.string(for: kSecAttrServer) {
             components.host = host
         }
-        if let port = keychainAttributes.int(for: kSecAttrPort){
+        if let port = keychainAttributes.int(for: kSecAttrPort) {
             components.port = port
         }
-        if let path = keychainAttributes.string(for: kSecAttrPath){
+        if let path = keychainAttributes.string(for: kSecAttrPath) {
             components.path = path
         }
         return components.url

--- a/MorphicCore/MorphicCore/Preferences.swift
+++ b/MorphicCore/MorphicCore/Preferences.swift
@@ -23,15 +23,15 @@
 
 import Foundation
 
-public struct Preferences: Codable, Record{
+public struct Preferences: Codable, Record {
     
     // MARK: - Creating Preferences
     
     /// Create a new preferences object from the given identifier
     ///
     /// Typically used for completely new users
-    public init(identifier: String){
-        self.identifier = identifier;
+    public init(identifier: String) {
+        self.identifier = identifier
     }
     
     // MARK: - Identifier
@@ -51,12 +51,12 @@ public struct Preferences: Codable, Record{
     /// The default map of solution identifier to solution prefs
     public var defaults: PreferencesSet?
     
-    public struct Key: Equatable, Hashable{
+    public struct Key: Equatable, Hashable {
         
         public var solution: String
         public var preference: String
         
-        public init(solution: String, preference: String){
+        public init(solution: String, preference: String) {
             self.solution = solution
             self.preference = preference
         }
@@ -64,12 +64,12 @@ public struct Preferences: Codable, Record{
     }
 
     /// The preferences for a specific solution
-    public struct Solution: Codable{
+    public struct Solution: Codable {
         
         /// Each solution can store arbitrary values
-        public var values = [String: Interoperable?]();
+        public var values = [String: Interoperable?]()
         
-        public init(){
+        public init() {
         }
         
         public init(from decoder: Decoder) throws {
@@ -84,40 +84,40 @@ public struct Preferences: Codable, Record{
         
     }
     
-    public mutating func set(_ value: Interoperable?, for key: Key){
-        if defaults == nil{
+    public mutating func set(_ value: Interoperable?, for key: Key) {
+        if defaults == nil {
             defaults = [:]
         }
-        if defaults?[key.solution] == nil{
+        if defaults?[key.solution] == nil {
             defaults?[key.solution] = Solution()
         }
         defaults?[key.solution]?.values[key.preference] = value
     }
     
-    public func get(key: Key) -> Interoperable?{
+    public func get(key: Key) -> Interoperable? {
         return defaults?[key.solution]?.values[key.preference] ?? nil
     }
     
-    public func remove(key: Key){
-        guard var defaults = defaults else{
+    public func remove(key: Key) {
+        guard var defaults = defaults else {
             return
         }
-        guard var solution = defaults[key.solution] else{
+        guard var solution = defaults[key.solution] else {
             return
         }
         solution.values.removeValue(forKey: key.preference)
-        if solution.values.count == 0{
+        if solution.values.count == 0 {
             defaults.removeValue(forKey: key.solution)
         }
     }
     
-    public func keyValueTuples() -> [(Key, Interoperable?)]{
+    public func keyValueTuples() -> [(Key, Interoperable?)] {
         var tuples = [(Key, Interoperable?)]()
-        guard let defaults = defaults else{
+        guard let defaults = defaults else {
             return tuples
         }
-        for (identifier, solution) in defaults{
-            for (name, value) in solution.values{
+        for (identifier, solution) in defaults {
+            for (name, value) in solution.values {
                 let key = Key(solution: identifier, preference: name)
                 tuples.append((key, value))
             }
@@ -127,7 +127,7 @@ public struct Preferences: Codable, Record{
     
     // MARK: - Codable
     
-    enum CodingKeys: String, CodingKey{
+    enum CodingKeys: String, CodingKey {
         case identifier = "id"
         case userId = "user_id"
         case defaults = "default"

--- a/MorphicCore/MorphicCore/Storage.swift
+++ b/MorphicCore/MorphicCore/Storage.swift
@@ -27,18 +27,18 @@ import OSLog
 private let logger = OSLog(subsystem: "MorphicCore", category: "Storage")
 
 /// Application storage for Morphic on the local machine
-public class Storage{
+public class Storage {
     
     /// The singleton `Storage` instance
     public private(set) static var shared = Storage()
     
-    private init(){
+    private init() {
         fileManager = .default
         root = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first?.appendingPathComponent("org.raisingthefloor.Morphic", isDirectory: true).appendingPathComponent("Data", isDirectory: true)
         queue = DispatchQueue(label: "org.raisingthefloor.Morphic.Storage", qos: .background, attributes: [], autoreleaseFrequency: .inherit, target: nil)
     }
     
-    public init(root url: URL){
+    public init(root url: URL) {
         fileManager = .default
         root = url
         queue = DispatchQueue(label: "org.raisingthefloor.Morphic.Storage", qos: .background, attributes: [], autoreleaseFrequency: .inherit, target: nil)
@@ -55,7 +55,7 @@ public class Storage{
     
     // MARK: - Preferences
     
-    private func url(for identifier: String, type: Record.Type) -> URL?{
+    private func url(for identifier: String, type: Record.Type) -> URL? {
         return root?.appendingPathComponent(type.typeName, isDirectory: true).appendingPathComponent(identifier).appendingPathExtension("json")
     }
     
@@ -65,9 +65,9 @@ public class Storage{
     ///   - encodable: The object to save
     ///   - completion: The block to call when the save request completes
     ///   - success: Whether the object was saved successfully to disk
-    public func save<RecordType>(record: RecordType, completion: @escaping (_ success: Bool) -> Void) where RecordType: Encodable, RecordType: Record{
+    public func save<RecordType>(record: RecordType, completion: @escaping (_ success: Bool) -> Void) where RecordType: Encodable, RecordType: Record {
         queue.async {
-            guard let url = self.url(for: record.identifier, type: RecordType.self) else{
+            guard let url = self.url(for: record.identifier, type: RecordType.self) else {
                 os_log(.error, log: logger, "Could not obtain a valid file url for saving")
                 DispatchQueue.main.async {
                     completion(false)
@@ -75,16 +75,16 @@ public class Storage{
                 return
             }
             let encoder = JSONEncoder()
-            guard let json = try? encoder.encode(record) else{
+            guard let json = try? encoder.encode(record) else {
                 os_log(.error, log: logger, "Failed to encode to JSON")
                 DispatchQueue.main.async {
                     completion(false)
                 }
                 return
             }
-            do{
+            do {
                 try self.fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)
-            }catch{
+            } catch {
                 os_log(.error, log: logger, "Failed to create directory")
                 DispatchQueue.main.async {
                     completion(false)
@@ -104,16 +104,16 @@ public class Storage{
     ///   - identifier: The identifier of the object to load
     ///   - completion: The block to call with the loaded object
     ///   - document: The loaded object, or `nil` if no such identifier was saved
-    public func load<RecordType>(identifier: String, completion: @escaping (_ document: RecordType?) -> Void) where RecordType: Decodable, RecordType: Record{
+    public func load<RecordType>(identifier: String, completion: @escaping (_ document: RecordType?) -> Void) where RecordType: Decodable, RecordType: Record {
         queue.async {
-            guard let url = self.url(for: identifier, type: RecordType.self) else{
+            guard let url = self.url(for: identifier, type: RecordType.self) else {
                 os_log(.error, log: logger, "Could not obtain a valid file url for loading")
                 DispatchQueue.main.async {
                     completion(nil)
                 }
                 return
             }
-            guard let data = self.fileManager.contents(atPath: url.path) else{
+            guard let data = self.fileManager.contents(atPath: url.path) else {
                 os_log(.error, log: logger, "Could not read data")
                 DispatchQueue.main.async {
                     completion(nil)
@@ -121,7 +121,7 @@ public class Storage{
                 return
             }
             let decoder = JSONDecoder()
-            guard let record = try? decoder.decode(RecordType.self, from: data) else{
+            guard let record = try? decoder.decode(RecordType.self, from: data) else {
                 os_log(.error, log: logger, "Could not decode JSON")
                 DispatchQueue.main.async {
                     completion(nil)
@@ -138,8 +138,8 @@ public class Storage{
     /// - parameters:
     ///   - identifier: The identifier of the object to load
     ///   - type: The type of record
-    public func contains(identifier: String, type: Record.Type) -> Bool{
-        guard let url = self.url(for: identifier, type: type) else{
+    public func contains(identifier: String, type: Record.Type) -> Bool {
+        guard let url = self.url(for: identifier, type: type) else {
             os_log(.error, log: logger, "Could not obtain a valid file url for loading")
             return false
         }

--- a/MorphicCore/MorphicCore/User.swift
+++ b/MorphicCore/MorphicCore/User.swift
@@ -24,14 +24,14 @@
 import Foundation
 
 /// A Morphic user
-public struct User: Codable, Record{
+public struct User: Codable, Record {
     
     // MARK: - Creating a User
     
     /// Create a new user by generating a new globally unique identifier
     ///
     /// Typically used for completely new users
-    public init(){
+    public init() {
         identifier = UUID().uuidString
         preferencesId = UUID().uuidString
     }
@@ -47,7 +47,7 @@ public struct User: Codable, Record{
     
     // MARK: - Codable
     
-    enum CodingKeys: String, CodingKey{
+    enum CodingKeys: String, CodingKey {
         case identifier = "id"
         case preferencesId = "preferences_id"
         case firstName = "first_name"
@@ -55,7 +55,7 @@ public struct User: Codable, Record{
         case email = "email"
     }
     
-    public init(from decoder: Decoder) throws{
+    public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         identifier = try container.decode(String.self, forKey: .identifier)
         preferencesId = try container.decode(String?.self, forKey: .preferencesId)
@@ -64,7 +64,7 @@ public struct User: Codable, Record{
         email = try container.decodeIfPresent(String.self, forKey: .email)
     }
     
-    public func encode(to encoder: Encoder) throws{
+    public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(identifier, forKey: .identifier)
         try container.encode(preferencesId, forKey: .preferencesId)

--- a/MorphicCore/MorphicCore/UserDeafults+Morphic.swift
+++ b/MorphicCore/MorphicCore/UserDeafults+Morphic.swift
@@ -26,19 +26,19 @@ import Foundation
 public extension UserDefaults {
     static var morphic = UserDefaults(suiteName: "org.raisingthefloor.MorphicLite")!
     
-    func morphicUsername(for userIdentifier: String) -> String?{
+    func morphicUsername(for userIdentifier: String) -> String? {
         let usernamesByIdentifier = dictionary(forKey: .morphicDefaultsKeyUsernamesByIdentifier)
         return usernamesByIdentifier?[userIdentifier] as? String
     }
     
-    func set(morphicUsername: String, for userIdentifier: String){
+    func set(morphicUsername: String, for userIdentifier: String) {
         var usernamesByIdentifier = dictionary(forKey: .morphicDefaultsKeyUsernamesByIdentifier) ?? [String: Any]()
         usernamesByIdentifier[userIdentifier] = morphicUsername
         setValue(usernamesByIdentifier, forKey: .morphicDefaultsKeyUsernamesByIdentifier)
     }
 }
 
-public extension String{
+public extension String {
     static var morphicDefaultsKeyUserIdentifier = "userIdentifier"
     static var morphicDefaultsKeyUsernamesByIdentifier = "usernamesByIdentifier"
 }

--- a/MorphicManualTester/MorphicManualTester/AppDelegate.swift
+++ b/MorphicManualTester/MorphicManualTester/AppDelegate.swift
@@ -1,10 +1,25 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  AppDelegate.swift
-//  MorphicManualTester
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by James Vanderheiden on 7/15/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import Cocoa
 import SwiftUI
@@ -27,15 +42,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         window.setFrameAutosaveName("Main Window")
         window.contentView = NSHostingView(rootView: contentView)
         window.makeKeyAndOrderFront(nil)
-        registry.LoadSolution()
+        registry.loadSolution()
     }
 
     func applicationWillTerminate(_ aNotification: Notification) {
         // Insert code here to tear down your application
     }
 
-    @IBAction func LoadSolution(_ sender: NSMenuItem) {
-        registry.LoadSolution()
+    @IBAction func loadSolution(_ sender: NSMenuItem) {
+        registry.loadSolution()
     }
 
 }

--- a/MorphicManualTester/MorphicManualTester/Base.lproj/Main.storyboard
+++ b/MorphicManualTester/MorphicManualTester/Base.lproj/Main.storyboard
@@ -65,7 +65,7 @@
                                         </menuItem>
                                         <menuItem title="Open…" keyEquivalent="o" id="IAo-SY-fd9">
                                             <connections>
-                                                <action selector="LoadSolution:" target="Voe-Tx-rLC" id="5Tl-kd-1dm"/>
+                                                <action selector="loadSolution:" target="Voe-Tx-rLC" id="5Tl-kd-1dm"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Open Recent" id="tXI-mr-wws">

--- a/MorphicManualTester/MorphicManualTester/ContentView.swift
+++ b/MorphicManualTester/MorphicManualTester/ContentView.swift
@@ -1,10 +1,25 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  ContentView.swift
-//  MorphicManualTester
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by James Vanderheiden on 7/15/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import SwiftUI
 
@@ -22,7 +37,7 @@ struct ContentView: View {
                         .multilineTextAlignment(.leading)
                         .padding()
                     Spacer()
-                    Button(action: registry.LoadSolution) {
+                    Button(action: registry.loadSolution) {
                         Text("Load a Different Registry")
                     }
                     .padding([.top, .bottom, .trailing])
@@ -51,7 +66,7 @@ struct ContentView: View {
                 .padding(.vertical)
                 HStack {
                     if(!manager.autoApply) {
-                        Button(action: registry.ApplyAllSettings) {
+                        Button(action: registry.applyAllSettings) {
                             Text("Apply Settings")
                         }
                     }

--- a/MorphicManualTester/MorphicManualTester/RegistryManager.swift
+++ b/MorphicManualTester/MorphicManualTester/RegistryManager.swift
@@ -1,10 +1,25 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  RegistryManager.swift
-//  MorphicManualTester
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by CatalinaTest on 7/20/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import Foundation
 import MorphicCore
@@ -21,16 +36,12 @@ class SettingControl: ObservableObject, Identifiable
     @Published var changed: Bool
     @Published var loading: Bool
     @Published var displayVal: String
-    @Published var displayBool: Bool
-        {
-        didSet
-        {
-            if val_bool != displayBool
-            {
+    @Published var displayBool: Bool {
+        didSet {
+            if val_bool != displayBool {
                 changed = true
-                if registry.autoApply
-                {
-                    CheckVal(isStart: false)
+                if registry.autoApply {
+                    checkVal(isStart: false)
                 }
             }
         }
@@ -40,8 +51,8 @@ class SettingControl: ObservableObject, Identifiable
     var val_int: Int
     var val_double: Double
     var solutionName: String
-    init(name: String, solname: String, type: Setting.ValueType, val_string: String = "", val_bool: Bool = false, val_double: Double = 0.0, val_int: Int = 0)
-    {
+    
+    init(name: String, solname: String, type: Setting.ValueType, val_string: String = "", val_bool: Bool = false, val_double: Double = 0.0, val_int: Int = 0) {
         self.name = name
         self.type = type
         self.wrong = false
@@ -55,25 +66,23 @@ class SettingControl: ObservableObject, Identifiable
         self.displayVal = ""
         self.displayBool = false
     }
-    func copy() -> SettingControl
-    {
+    
+    func copy() -> SettingControl {
         let copy = SettingControl(name: name, solname: solutionName, type: type)
         copy.val_bool = val_bool
         copy.val_int = val_int
         copy.val_string = val_string
         copy.val_double = val_double
-        return copy;
+        return copy
     }
-    func CheckVal(isStart: Bool)
-    {
+    
+    func checkVal(isStart: Bool) {
         wrong = false
         if isStart {return}
         changed = true
-        switch(type)
-        {
+        switch type {
         case .string:
             val_string = displayVal
-            break
         case .integer:
             let ival: Int? = Int(displayVal)
             if ival == nil
@@ -82,7 +91,6 @@ class SettingControl: ObservableObject, Identifiable
                 return
             }
             val_int = ival!
-            break
         case .double:
             let dval: Double? = Double(displayVal)
             if dval == nil
@@ -91,88 +99,70 @@ class SettingControl: ObservableObject, Identifiable
                 return
             }
             val_double = dval!
-            break
         case .boolean:
             val_bool = displayBool
-            break
         }
-        if(registry.autoApply)
-        {
-            Apply(alreadyChecked: true)
+        if registry.autoApply {
+            apply(alreadyChecked: true)
         }
     }
-    func Apply(alreadyChecked: Bool = false)
-    {
+    
+    func apply(alreadyChecked: Bool = false) {
         self.loading = true
-        if !changed
-        {
+        if !changed {
             return
         }
-        if !alreadyChecked
-        {
-            CheckVal(isStart: false)
+        if !alreadyChecked {
+            checkVal(isStart: false)
         }
         var val: Interoperable?
-        switch(type)
-        {
+        switch type {
         case .string:
             val = val_string
-            break
         case .integer:
             val = val_int
-            break
         case .double:
             val = val_double
-            break
         case .boolean:
             val = val_bool
-            break
         }
         let sname = String(name)
-        SettingsManager.shared.apply(val, for: Preferences.Key(solution: solutionName, preference: sname))
-        { success in
-            if(!success)
-            {
-                self.Capture()
-            }
-            else
-            {
+        SettingsManager.shared.apply(val, for: Preferences.Key(solution: solutionName, preference: sname)) { success in
+            if !success {
+                self.capture()
+            } else {
                 self.loading = false
             }
         }
     }
-    func Capture()
-    {
+    
+    func capture() {
         self.loading = true
         let sname = String(name)
-        SettingsManager.shared.capture(valueFor: Preferences.Key(solution: solutionName, preference: sname))
-        { value in
-            switch(self.type)
-            {
+        SettingsManager.shared.capture(valueFor: Preferences.Key(solution: solutionName, preference: sname)) { value in
+            switch self.type {
             case .string:
                 let v_string: String? = value as? String
-                if v_string == nil {return}
+                if v_string == nil {
+                    return
+                }
                 self.val_string = v_string!
                 self.displayVal = self.val_string
-                break
             case .boolean:
                 let v_bool: Bool? = value as? Bool
                 if v_bool == nil {return}
                 self.val_bool = v_bool!
                 self.displayBool = self.val_bool
-                break
             case .integer:
                 let v_int: Int? = value as? Int
                 if v_int == nil {return}
                 self.val_int = v_int!
                 self.displayVal = String(format: "%i", self.val_int)
-                break
             case .double:
                 let v_double: Double? = value as? Double
                 if v_double == nil {return}
                 self.val_double = v_double!
                 self.displayVal = String(format: "%f", self.val_double)
-                break
             }
             self.loading = false
             self.changed = false
@@ -185,35 +175,32 @@ class SolutionCollection: ObservableObject, Identifiable
 {
     @Published var name: String
     @Published var settings: [SettingControl]
-    init(solutionName: String)
-    {
+    
+    init(solutionName: String) {
         self.name = solutionName
         self.settings = [SettingControl]()
     }
-    func copy() -> SolutionCollection
-    {
+    
+    func copy() -> SolutionCollection {
         let copy = SolutionCollection(solutionName: name)
-        for setting in settings
-        {
+        for setting in settings {
             copy.settings.append(setting.copy())
         }
         return copy;
     }
-    func ApplySettings()
-    {
-        for setting in self.settings
-        {
-            if(setting.changed)
-            {
-                setting.Apply()
+    
+    func applySettings() {
+        for setting in self.settings {
+            if setting.changed {
+                setting.apply()
             }
         }
     }
-    func CaptureSettings()
+    
+    func captureSettings()
     {
-        for setting in self.settings
-        {
-            setting.Capture()
+        for setting in self.settings {
+            setting.capture()
         }
     }
 }
@@ -223,35 +210,31 @@ class RegistryManager: ObservableObject
     @Published var solutions: [SolutionCollection]
     @Published var load: String
     @Published var autoApply: Bool
-    init()
-    {
+    
+    init() {
         load = "NO REGISTRY LOADED"
         autoApply = true
         solutions = [SolutionCollection]()
     }
-    func LoadSolution()
-    {
-        let filedialog = NSOpenPanel()
-        filedialog.message = "Please select a solution registry JSON file to load:"
-        filedialog.showsResizeIndicator = true
-        filedialog.showsHiddenFiles = false
-        filedialog.allowsMultipleSelection = false
-        filedialog.canChooseDirectories = false
-        if(filedialog.runModal() == NSApplication.ModalResponse.OK)
-        {
+    
+    func loadSolution() {
+        let fileDialog = NSOpenPanel()
+        fileDialog.message = "Please select a solution registry JSON file to load:"
+        fileDialog.showsResizeIndicator = true
+        fileDialog.showsHiddenFiles = false
+        fileDialog.allowsMultipleSelection = false
+        fileDialog.canChooseDirectories = false
+        if fileDialog.runModal() == NSApplication.ModalResponse.OK {
             let solurl = filedialog.url
-            if(solurl != nil)
-            {
+            if solurl != nil {
                 let solpath: String = solurl!.path
                 SettingsManager.shared.populateSolutions(from: solurl!)
-                if(SettingsManager.shared.solutions.isEmpty)
-                {
+                if SettingsManager.shared.solutions.isEmpty {
                     load = "ERROR, INVALID SOLUTION FILE. PLEASE TRY AGAIN."
                     return
                 }
                 solutions = [SolutionCollection]()
-                for solution in SettingsManager.shared.solutions
-                {
+                for solution in SettingsManager.shared.solutions {
                     let collection = SolutionCollection(solutionName: solution.identifier)
                     for setting in solution.settings
                     {
@@ -259,31 +242,26 @@ class RegistryManager: ObservableObject
                     }
                     solutions.append(collection)
                 }
-                CaptureAllSettings()
+                captureAllSettings()
                 load = "Loaded file " + solpath
             }
         }
     }
-    func ApplyAllSettings()
-    {
-        for solution in self.solutions
-        {
-            for setting in solution.settings
-            {
-                if setting.changed
-                {
-                    setting.Apply()
+    
+    func applyAllSettings() {
+        for solution in self.solutions {
+            for setting in solution.settings {
+                if setting.changed {
+                    setting.apply()
                 }
             }
         }
     }
-    func CaptureAllSettings()
-    {
-        for solution in self.solutions
-        {
-            for setting in solution.settings
-            {
-                setting.Capture()
+    
+    func captureAllSettings() {
+        for solution in self.solutions {
+            for setting in solution.settings {
+                setting.capture()
             }
         }
     }

--- a/MorphicManualTester/MorphicManualTester/RegistryManager.swift
+++ b/MorphicManualTester/MorphicManualTester/RegistryManager.swift
@@ -84,21 +84,17 @@ class SettingControl: ObservableObject, Identifiable
         case .string:
             val_string = displayVal
         case .integer:
-            let ival: Int? = Int(displayVal)
-            if ival == nil
-            {
+            guard let ival = Int(displayVal) else {
                 wrong = true
                 return
             }
-            val_int = ival!
+            val_int = ival
         case .double:
-            let dval: Double? = Double(displayVal)
-            if dval == nil
-            {
+            guard let dval = Double(displayVal) else {
                 wrong = true
                 return
             }
-            val_double = dval!
+            val_double = dval
         case .boolean:
             val_bool = displayBool
         }
@@ -149,19 +145,22 @@ class SettingControl: ObservableObject, Identifiable
                 self.val_string = v_string!
                 self.displayVal = self.val_string
             case .boolean:
-                let v_bool: Bool? = value as? Bool
-                if v_bool == nil {return}
-                self.val_bool = v_bool!
+                guard let v_bool = value as? Bool else {
+                    return
+                }
+                self.val_bool = v_bool
                 self.displayBool = self.val_bool
             case .integer:
-                let v_int: Int? = value as? Int
-                if v_int == nil {return}
-                self.val_int = v_int!
+                guard let v_int = value as? Int else {
+                    return
+                }
+                self.val_int = v_int
                 self.displayVal = String(format: "%i", self.val_int)
             case .double:
-                let v_double: Double? = value as? Double
-                if v_double == nil {return}
-                self.val_double = v_double!
+                guard let v_double = value as? Double else {
+                    return
+                }
+                self.val_double = v_double
                 self.displayVal = String(format: "%f", self.val_double)
             }
             self.loading = false
@@ -225,10 +224,9 @@ class RegistryManager: ObservableObject
         fileDialog.allowsMultipleSelection = false
         fileDialog.canChooseDirectories = false
         if fileDialog.runModal() == NSApplication.ModalResponse.OK {
-            let solurl = filedialog.url
-            if solurl != nil {
-                let solpath: String = solurl!.path
-                SettingsManager.shared.populateSolutions(from: solurl!)
+            if let solurl = fileDialog.url {
+                let solpath: String = solurl.path
+                SettingsManager.shared.populateSolutions(from: solurl)
                 if SettingsManager.shared.solutions.isEmpty {
                     load = "ERROR, INVALID SOLUTION FILE. PLEASE TRY AGAIN."
                     return

--- a/MorphicManualTester/MorphicManualTester/SolutionViews.swift
+++ b/MorphicManualTester/MorphicManualTester/SolutionViews.swift
@@ -1,10 +1,25 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  SolutionViews.swift
-//  MorphicManualTester
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by CatalinaTest on 7/20/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import SwiftUI
 import MorphicSettings
@@ -29,21 +44,18 @@ struct SolutionSection: View {
     var body: some View {
         VStack(spacing: 0.0) {
             HStack {
-                if(active)
-                {
+                if self.active {
                     Text("\u{25bc}")
                         .font(.headline)
-                }
-                else
-                {
+                } else {
                     Text("\u{25b6}")
                         .font(.headline)
                 }
                 Text(solution.name)
                     .font(.headline)
                 Spacer()
-                Button(action: {self.solution.CaptureSettings()}) {
-                Text("Refresh")
+                Button(action: {self.solution.captureSettings()}) {
+                    Text("Refresh")
                 }
             }
             .onTapGesture {
@@ -52,18 +64,15 @@ struct SolutionSection: View {
             .padding(.all)
             Section() {
                 ForEach(solution.settings) {setting in
-                    if(self.active) {
+                    if self.active {
                         Divider()
-                        if(setting.type == Setting.ValueType.boolean) {
+                        if setting.type == Setting.ValueType.boolean {
                             BooleanEntry(setting: setting)
-                        }
-                        else if(setting.type == Setting.ValueType.double) {
+                        } else if setting.type == Setting.ValueType.double {
                             DoubleEntry(setting: setting)
-                        }
-                        else if(setting.type == Setting.ValueType.integer) {
+                        } else if setting.type == Setting.ValueType.integer {
                             IntegerEntry(setting: setting)
-                        }
-                        else if(setting.type == Setting.ValueType.string) {
+                        } else if setting.type == Setting.ValueType.string {
                             StringEntry(setting: setting)
                         }
                     }
@@ -84,8 +93,8 @@ struct BooleanEntry: View {
             Text(setting.name)
                 .font(.subheadline)
             Spacer()
-            if(setting.loading) {
-            Image("Hourglass").resizable().frame(width: 11.0, height: 20.0)
+            if setting.loading {
+                Image("Hourglass").resizable().frame(width: 11.0, height: 20.0)
             }
             Text("Boolean:")
             Toggle("", isOn: $setting.displayBool)
@@ -102,11 +111,11 @@ struct IntegerEntry: View {
             Text(setting.name)
                 .font(.subheadline)
             Spacer()
-            if(setting.loading) {
-            Image("Hourglass").resizable().frame(width: 11.0, height: 20.0)
+            if setting.loading {
+                Image("Hourglass").resizable().frame(width: 11.0, height: 20.0)
             }
             Text("Integer:")
-            TextField("", text: $setting.displayVal, onEditingChanged: setting.CheckVal)
+            TextField("", text: $setting.displayVal, onEditingChanged: setting.checkVal)
                 .frame(width: 300.0)
                 .background(setting.wrong ? Color.red.opacity(0.2) : (setting.changed ? Color.green.opacity(0.2) : Color.clear))
         }
@@ -122,11 +131,11 @@ struct DoubleEntry: View {
             Text(setting.name)
                 .font(.subheadline)
             Spacer()
-            if(setting.loading) {
-            Image("Hourglass").resizable().frame(width: 11.0, height: 20.0)
+            if setting.loading {
+                Image("Hourglass").resizable().frame(width: 11.0, height: 20.0)
             }
             Text("Double:")
-            TextField("", text: $setting.displayVal, onEditingChanged: setting.CheckVal)
+            TextField("", text: $setting.displayVal, onEditingChanged: setting.checkVal)
                 .frame(width: 300.0)
                 .background(setting.wrong ? Color.red.opacity(0.2) : (setting.changed ? Color.green.opacity(0.2) : Color.clear))
         }
@@ -142,11 +151,11 @@ struct StringEntry: View {
             Text(setting.name)
                 .font(.subheadline)
             Spacer()
-            if(setting.loading) {
-            Image("Hourglass").resizable().frame(width: 11.0, height: 20.0)
+            if setting.loading {
+                Image("Hourglass").resizable().frame(width: 11.0, height: 20.0)
             }
             Text("String:")
-            TextField("", text: $setting.displayVal, onEditingChanged: setting.CheckVal)
+            TextField("", text: $setting.displayVal, onEditingChanged: setting.checkVal)
                 .frame(width: 300.0)
                 .background(setting.wrong ? Color.red.opacity(0.2) : (setting.changed ? Color.green.opacity(0.2) : Color.clear))
         }

--- a/MorphicService/MorphicService/AuthService.swift
+++ b/MorphicService/MorphicService/AuthService.swift
@@ -25,7 +25,7 @@ import Foundation
 import MorphicCore
 
 /// Interface to the remote Morphic auth server
-public extension Service{
+public extension Service {
     
     // MARK: - Requests
     
@@ -38,10 +38,10 @@ public extension Service{
     ///   - completion: The block to call when the task has completed
     ///   - authentication: The authentication response
     /// - returns: The URL session task that is making the remote request for preferences data
-    func register(user: User, username: String, password: String, completion: @escaping (_ result: RegistrationResult) -> Void) -> Session.Task{
+    func register(user: User, username: String, password: String, completion: @escaping (_ result: RegistrationResult) -> Void) -> Session.Task {
         let body = RegisterUsernameRequest(username: username, password: password, firstName: user.firstName, lastName: user.lastName, email: user.email)
         let request = URLRequest(session: session, path: "v1/register/username", method: .post, body: body)
-        return session.runningTask(with: request){
+        return session.runningTask(with: request) {
             (response: Response<AuthentiationResponse, RegisterUsernameBadRequest>) in
             switch response{
             case .success(let auth):
@@ -74,17 +74,17 @@ public extension Service{
     ///   - completion: The block to call when the task has completed
     ///   - authentication: The authentication response
     /// - returns: The URL session task that is making the remote request for preferences data
-    func register(user: User, key: String, completion: @escaping (_ authentication: AuthentiationResponse?) -> Void) -> Session.Task{
+    func register(user: User, key: String, completion: @escaping (_ authentication: AuthentiationResponse?) -> Void) -> Session.Task {
         let body = RegisterKeyRequest(key: key, firstName: user.firstName, lastName: user.lastName)
         let request = URLRequest(session: session, path: "v1/register/key", method: .post, body: body)
         return session.runningTask(with: request, completion: completion)
     }
     
-    func authenticate(credentials: Credentials, completion: @escaping (_ authentication: AuthentiationResponse?) -> Void) -> Session.Task{
-        if let keyCredentials = credentials as? KeyCredentials{
+    func authenticate(credentials: Credentials, completion: @escaping (_ authentication: AuthentiationResponse?) -> Void) -> Session.Task {
+        if let keyCredentials = credentials as? KeyCredentials {
             return authenticate(key: keyCredentials.key, completion: completion)
         }
-        if let usernameCredentials = credentials as? UsernameCredentials{
+        if let usernameCredentials = credentials as? UsernameCredentials {
             return authenticate(username: usernameCredentials.username, password: usernameCredentials.password, completion: completion)
         }
         return session.runningTask(with: nil, completion: completion)
@@ -98,7 +98,7 @@ public extension Service{
     ///   - completion: The block to call when the task has completed
     ///   - authentication: The authentication response
     /// - returns: The URL session task that is making the remote request for preferences data
-    func authenticate(username: String, password: String, completion: @escaping (_ authentication: AuthentiationResponse?) -> Void) -> Session.Task{
+    func authenticate(username: String, password: String, completion: @escaping (_ authentication: AuthentiationResponse?) -> Void) -> Session.Task {
         let body = AuthUsernameRequest(username: username, password: password)
         let request = URLRequest(session: session, path: "v1/auth/username", method: .post, body: body)
         return session.runningTask(with: request, completion: completion)
@@ -111,7 +111,7 @@ public extension Service{
     ///   - completion: The block to call when the task has loaded
     ///   - success: Whether the save request succeeded
     /// - returns: The URL session task that is making the remote request for preferences data
-    func authenticate(key: String, completion: @escaping (_ authentication: AuthentiationResponse?) -> Void) -> Session.Task{
+    func authenticate(key: String, completion: @escaping (_ authentication: AuthentiationResponse?) -> Void) -> Session.Task {
         let body = AuthKeyRequest(key: key)
         let request = URLRequest(session: session, path: "v1/auth/key", method: .post, body: body)
         return session.runningTask(with: request, completion: completion)
@@ -119,7 +119,7 @@ public extension Service{
     
 }
 
-struct RegisterUsernameRequest: Codable{
+struct RegisterUsernameRequest: Codable {
     public var username: String
     public var password: String
     public var firstName: String?
@@ -127,10 +127,10 @@ struct RegisterUsernameRequest: Codable{
     public var email: String?
 }
 
-struct RegisterUsernameBadRequest: Codable{
+struct RegisterUsernameBadRequest: Codable {
     public var error: InputError?
     
-    public enum InputError: String, Codable{
+    public enum InputError: String, Codable {
         case existingUsername = "existing_username"
         case existingEmail = "existing_email"
         case malformedEmail = "malformed_email"
@@ -139,13 +139,13 @@ struct RegisterUsernameBadRequest: Codable{
     }
 }
 
-struct RegisterKeyRequest: Codable{
+struct RegisterKeyRequest: Codable {
     public var key: String
     public var firstName: String?
     public var lastName: String?
 }
 
-public enum RegistrationResult{
+public enum RegistrationResult {
     case success(authentication: AuthentiationResponse)
     case badPassword
     case existingEmail
@@ -153,16 +153,16 @@ public enum RegistrationResult{
     case error
 }
 
-struct AuthUsernameRequest: Codable{
+struct AuthUsernameRequest: Codable {
     public var username: String
     public var password: String
 }
 
-struct AuthKeyRequest: Codable{
+struct AuthKeyRequest: Codable {
     public var key: String
 }
 
-public struct AuthentiationResponse: Codable{
+public struct AuthentiationResponse: Codable {
     
     /// The authentication token to be used in the `X-Morphic-Auth-Token` header of subsequent requests
     public var token: String

--- a/MorphicService/MorphicService/PreferencesService.swift
+++ b/MorphicService/MorphicService/PreferencesService.swift
@@ -25,7 +25,7 @@ import Foundation
 import MorphicCore
 
 /// Interface to the remote Morphic preferences server
-public extension Service{
+public extension Service {
     
     // MARK: - Requests
     
@@ -36,7 +36,7 @@ public extension Service{
     ///   - completion: The block to call when the task has loaded
     ///   - preferences: The preferences for the user, if the load was successful
     /// - returns: The URL session task that is making the remote request for preferences data
-    func fetch(userPreferences user: User, completion: @escaping (_ preferences: Preferences?) -> Void) -> Session.Task{
+    func fetch(userPreferences user: User, completion: @escaping (_ preferences: Preferences?) -> Void) -> Session.Task {
         let request = URLRequest(session: session, path: "v1/users/\(user.identifier)/preferences/\(user.preferencesId!)", method: .get)
         return session.runningTask(with: request, completion: completion)
     }
@@ -49,7 +49,7 @@ public extension Service{
     ///   - completion: The block to call when the task has loaded
     ///   - success: Whether the save request succeeded
     /// - returns: The URL session task that is making the remote request for preferences data
-    func save(_ preferences: Preferences, completion: @escaping (_ success: Bool) -> Void) -> Session.Task{
+    func save(_ preferences: Preferences, completion: @escaping (_ success: Bool) -> Void) -> Session.Task {
         let request = URLRequest(session: session, path: "v1/users/\(preferences.userId!)/preferences/\(preferences.identifier)", method: .put, body: preferences)
         return session.runningTask(with: request, completion: completion)
     }

--- a/MorphicService/MorphicService/Service.swift
+++ b/MorphicService/MorphicService/Service.swift
@@ -28,7 +28,7 @@ import OSLog
 private let logger = OSLog(subsystem: "MorphicService", category: "Service")
 
 /// Base class for all morphic services
-public class Service{
+public class Service {
     
     // MARK: - Creating a Service
     
@@ -37,7 +37,7 @@ public class Service{
     /// - parameters:
     ///   - endpoint: The location of the remote server
     ///   - session: The URL session to use for requests to the remote server
-    public init(endpoint: URL, session: Session){
+    public init(endpoint: URL, session: Session) {
         self.endpoint = endpoint
         self.session = session
     }
@@ -50,7 +50,7 @@ public class Service{
     /// The URL session to use when making requests to the remote server
     public private(set) weak var session: Session!
     
-    public enum Response<ResponseBody, BadRequestBody>{
+    public enum Response<ResponseBody, BadRequestBody> {
         case success(body: ResponseBody)
         case badRequest(body: BadRequestBody)
         case failed

--- a/MorphicService/MorphicService/UserService.swift
+++ b/MorphicService/MorphicService/UserService.swift
@@ -25,7 +25,7 @@ import Foundation
 import MorphicCore
 
 /// Interface to the remote Morphic preferences server
-public extension Service{
+public extension Service {
     
     // MARK: - Requests
     
@@ -36,7 +36,7 @@ public extension Service{
     ///   - completion: The block to call when the task has loaded
     ///   - user: The user, if the load was successful
     /// - returns: The URL session task that is making the remote request for user data
-    func fetch(user identifier: String, completion: @escaping (_ user: User?) -> Void) -> Session.Task{
+    func fetch(user identifier: String, completion: @escaping (_ user: User?) -> Void) -> Session.Task {
         let request = URLRequest(session: session, path: "v1/users/\(identifier)", method: .get)
         return session.runningTask(with: request, completion: completion)
     }
@@ -49,7 +49,7 @@ public extension Service{
     ///   - completion: The block to call when the task has loaded
     ///   - success: Whether the save request succeeded
     /// - returns: The URL session task that is making the remote request for user data
-    func save(_ user: User, completion: @escaping (_ success: Bool) -> Void) -> Session.Task{
+    func save(_ user: User, completion: @escaping (_ success: Bool) -> Void) -> Session.Task {
         let request = URLRequest(session: session, path: "v1/preferences/\(user.identifier)", method: .put, body: user)
         return session.runningTask(with: request, completion: completion)
     }

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/ApplicationElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/ApplicationElement.swift
@@ -27,10 +27,10 @@ import OSLog
 
 private let logger = OSLog(subsystem: "MorphicSettings", category: "ApplicationElement")
 
-public class ApplicationElement: UIElement{
+public class ApplicationElement: UIElement {
     
-    public static func from(bundleIdentifier: String) -> ApplicationElement{
-        switch bundleIdentifier{
+    public static func from(bundleIdentifier: String) -> ApplicationElement {
+        switch bundleIdentifier {
         case "com.apple.systempreferences":
             return SystemPreferencesElement()
         default:
@@ -38,7 +38,7 @@ public class ApplicationElement: UIElement{
         }
     }
     
-    public init(bundleIdentifier: String){
+    public init(bundleIdentifier: String) {
         self.bundleIdentifier = bundleIdentifier
         super.init(accessibilityElement: nil)
     }
@@ -51,21 +51,21 @@ public class ApplicationElement: UIElement{
     
     private var runningApplication: NSRunningApplication?
     
-    public func open(completion: @escaping (_ success: Bool) -> Void){
-        guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) else{
+    public func open(completion: @escaping (_ success: Bool) -> Void) {
+        guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) else {
             os_log(.error, log: logger, "Failed to find url for application %{public}s", bundleIdentifier)
             completion(false)
             return
         }
-        guard runningApplication == nil || runningApplication!.isTerminated else{
+        guard runningApplication == nil || runningApplication!.isTerminated else {
             completion(true)
             return
         }
         let complete = {
             let runningApplication: NSRunningApplication! = self.runningApplication
-            self.wait(atMost: 5.0, for: { runningApplication.isFinishedLaunching }){
+            self.wait(atMost: 5.0, for: { runningApplication.isFinishedLaunching }) {
                 success in
-                guard success else{
+                guard success else {
                     os_log(.error, log: logger, "Timeout waiting for isFinishLaunching")
                     completion(false)
                     return
@@ -80,7 +80,7 @@ public class ApplicationElement: UIElement{
                 } catch {
                     // no other errors should be throws by MorphicA11yUIElement.createFromProcess
                 }
-                guard accessibilityElement != nil else{
+                guard accessibilityElement != nil else {
                     os_log(.error, log: logger, "Failed to get automation element for application")
                     completion(false)
                     return
@@ -90,11 +90,11 @@ public class ApplicationElement: UIElement{
             }
         }
         runningApplication = NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier).first
-        if runningApplication == nil{
+        if runningApplication == nil {
             let config = NSWorkspace.OpenConfiguration()
             config.activates = false
             config.hides = true
-            NSWorkspace.shared.openApplication(at: url, configuration: config){
+            NSWorkspace.shared.openApplication(at: url, configuration: config) {
                 (runningApplication, error) in
                 DispatchQueue.main.async {
                     guard runningApplication != nil else{
@@ -107,27 +107,27 @@ public class ApplicationElement: UIElement{
                     complete()
                 }
             }
-        }else{
+        } else {
             complete()
         }
     }
     
     public func terminate() -> Bool{
-        guard let runningApplication = runningApplication else{
+        guard let runningApplication = runningApplication else {
             return true
         }
-        guard !runningApplication.isTerminated else{
+        guard !runningApplication.isTerminated else {
             return true
         }
         return runningApplication.terminate()
     }
     
-    public var mainWindow: WindowElement?{
+    public var mainWindow: WindowElement? {
         get{
-            guard accessibilityElement != nil else{
+            guard accessibilityElement != nil else {
                 return nil
             }
-            guard let mainWindow: MorphicA11yUIElement = accessibilityElement.value(forAttribute: .mainWindow) else{
+            guard let mainWindow: MorphicA11yUIElement = accessibilityElement.value(forAttribute: .mainWindow) else {
                 return nil
             }
             return WindowElement(accessibilityElement: mainWindow)

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/Controls/ButtonElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/Controls/ButtonElement.swift
@@ -23,16 +23,16 @@
 
 import Foundation
 
-public class ButtonElement: UIElement{
+public class ButtonElement: UIElement {
     
-    public var enabled: Bool{
+    public var enabled: Bool {
         get{
             return accessibilityElement.supportedActions()?.contains(.press) ?? false
         }
     }
     
-    public func press() -> Bool{
-        guard enabled else{
+    public func press() -> Bool {
+        guard enabled else {
             return false
         }
         return accessibilityElement.perform(action: .press)

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/Controls/CheckboxElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/Controls/CheckboxElement.swift
@@ -23,9 +23,9 @@
 
 import Foundation
 
-public class CheckboxElement: UIElement{
+public class CheckboxElement: UIElement {
     
-    public enum State{
+    public enum State {
         case checked
         case unchecked
         case mixed
@@ -33,29 +33,29 @@ public class CheckboxElement: UIElement{
     }
     
     public var state: State {
-        guard let checked: Bool = accessibilityElement.value(forAttribute: .value) else{
+        guard let checked: Bool = accessibilityElement.value(forAttribute: .value) else {
             return .unknown
         }
-        if checked{
+        if checked {
             return .checked
         }
         return .unchecked
     }
     
-    public func setChecked(_ checked: Bool) -> Bool{
-        if checked{
+    public func setChecked(_ checked: Bool) -> Bool {
+        if checked {
             return check()
-        }else{
+        } else {
             return uncheck()
         }
     }
     
-    public func check() -> Bool{
-        switch state{
+    public func check() -> Bool {
+        switch state {
         case .checked:
             return true
         case .unchecked, .mixed:
-            if !accessibilityElement.perform(action: .press){
+            if !accessibilityElement.perform(action: .press) {
                 return false
             }
             return state == .checked
@@ -64,12 +64,12 @@ public class CheckboxElement: UIElement{
         }
     }
     
-    public func uncheck() -> Bool{
+    public func uncheck() -> Bool {
         switch state{
         case .unchecked:
             return true
         case .checked, .mixed:
-            if !accessibilityElement.perform(action: .press){
+            if !accessibilityElement.perform(action: .press) {
                 return false
             }
             return state == .unchecked

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/Controls/LabelElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/Controls/LabelElement.swift
@@ -23,11 +23,11 @@
 
 import Foundation
 
-public class LabelElement: UIElement{
+public class LabelElement: UIElement {
     
-    public var text: String?{
+    public var text: String? {
         get{
-            guard let value: String = accessibilityElement.value(forAttribute: .value) else{
+            guard let value: String = accessibilityElement.value(forAttribute: .value) else {
                 return nil
             }
             return value

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/Controls/PopUpButtonElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/Controls/PopUpButtonElement.swift
@@ -1,37 +1,52 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  SelectElement.swift
-//  MorphicSettings
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by Owen Shaw on 6/29/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import Foundation
 
-public class PopUpButtonElement: UIElement{
+public class PopUpButtonElement: UIElement {
     
-    public var value: String?{
+    public var value: String? {
         get{
             accessibilityElement.value(forAttribute: .value)
         }
     }
     
-    public func setValue(_ value: String, completion: @escaping (_ success: Bool) -> Void){
-        guard accessibilityElement.perform(action: .showMenu) else{
+    public func setValue(_ value: String, completion: @escaping (_ success: Bool) -> Void) {
+        guard accessibilityElement.perform(action: .showMenu) else {
             completion(false)
             return
         }
-        self.wait(atMost: 2.0, for: { self.menu != nil }){
+        self.wait(atMost: 2.0, for: { self.menu != nil }) {
             sucess in
-            guard let menu = self.menu else{
+            guard let menu = self.menu else {
                 completion(false)
                 return
             }
-            guard menu.select(itemTitled: value) else{
+            guard menu.select(itemTitled: value) else {
                 completion(false)
                 return
             }
-            self.wait(atMost: 2.0, for: { self.value == value }){
+            self.wait(atMost: 2.0, for: { self.value == value }) {
                 success in
                 completion(success)
             }

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/Controls/SliderElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/Controls/SliderElement.swift
@@ -1,23 +1,38 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  SliderElement.swift
-//  MorphicSettings
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by Owen Shaw on 6/29/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import Foundation
 
-public class SliderElement: UIElement{
+public class SliderElement: UIElement {
     
-    public var value: Double?{
+    public var value: Double? {
         get{
             accessibilityElement.value(forAttribute: .value)
         }
     }
     
-    public func setValue(_ value: Double) -> Bool{
-        guard accessibilityElement.setValue(value, forAttribute: .value) else{
+    public func setValue(_ value: Double) -> Bool {
+        guard accessibilityElement.setValue(value, forAttribute: .value) else {
             return false
         }
         return true

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/Controls/TabElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/Controls/TabElement.swift
@@ -23,16 +23,16 @@
 
 import Foundation
 
-public class TabElement: UIElement{
+public class TabElement: UIElement {
     
-    public enum State{
+    public enum State {
         case normal
         case selected
         case unknown
     }
     
     public var state: State {
-        guard let selected: Bool = accessibilityElement.value(forAttribute: .value) else{
+        guard let selected: Bool = accessibilityElement.value(forAttribute: .value) else {
             return .unknown
         }
         if selected{
@@ -41,12 +41,12 @@ public class TabElement: UIElement{
         return .normal
     }
     
-    public func select() -> Bool{
+    public func select() -> Bool {
         switch state{
         case .selected:
             return true
         case .normal:
-            if !accessibilityElement.perform(action: .press){
+            if !accessibilityElement.perform(action: .press) {
                 return false
             }
             return state == .selected

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/Controls/TabGroupElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/Controls/TabGroupElement.swift
@@ -23,20 +23,20 @@
 
 import Foundation
 
-public class TabGroupElement: UIElement{
+public class TabGroupElement: UIElement {
     
-    public func select(tabTitled title: String) -> Bool{
-        guard let tab = self.tab(titled: title) else{
+    public func select(tabTitled title: String) -> Bool {
+        guard let tab = self.tab(titled: title) else {
             return false
         }
         return tab.select()
     }
     
-    public func tab(titled: String) -> TabElement?{
-        guard let tabs: [MorphicA11yUIElement] = accessibilityElement.values(forAttribute: .tabs) else{
+    public func tab(titled: String) -> TabElement? {
+        guard let tabs: [MorphicA11yUIElement] = accessibilityElement.values(forAttribute: .tabs) else {
             return nil
         }
-        guard let tab = tabs.first(where: { $0.value(forAttribute: .title) == titled }) else{
+        guard let tab = tabs.first(where: { $0.value(forAttribute: .title) == titled }) else {
             return nil
         }
         return TabElement(accessibilityElement: tab)

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/KeyEvents.h
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/KeyEvents.h
@@ -1,10 +1,25 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  KeyEvents.h
-//  MorphicSettings
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by Owen Shaw on 6/27/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 #import <Foundation/Foundation.h>
 

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/KeyEvents.m
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/KeyEvents.m
@@ -1,10 +1,25 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  KeyEvents.m
-//  MorphicSettings
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by Owen Shaw on 6/27/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 #import "KeyEvents.h"
 

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/Menus/MenuElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/Menus/MenuElement.swift
@@ -1,29 +1,44 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  MenuElement.swift
-//  MorphicSettings
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by Owen Shaw on 7/4/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import Foundation
 
-public class MenuElement: UIElement{
+public class MenuElement: UIElement {
     
-    public func select(itemTitled title: String) -> Bool{
-        guard items.first(where: { $0.title == title })?.select() ?? false else{
+    public func select(itemTitled title: String) -> Bool {
+        guard items.first(where: { $0.title == title })?.select() ?? false else {
             return false
         }
         return true
     }
     
-    public var items: [MenuItemElement]{
-        guard let children = accessibilityElement.children() else{
+    public var items: [MenuItemElement] {
+        guard let children = accessibilityElement.children() else {
             return []
         }
         var items = [MenuItemElement]()
         for child in children{
-            if child.role == .menuItem{
+            if child.role == .menuItem {
                 items.append(MenuItemElement(accessibilityElement: child))
             }
         }

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/Menus/MenuItemElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/Menus/MenuItemElement.swift
@@ -1,21 +1,36 @@
+// Copyright 2020 Raising the Floor - International
 //
-//  MenuItemElement.swift
-//  MorphicSettings
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
 //
-//  Created by Owen Shaw on 7/4/20.
-//  Copyright © 2020 Raising the Floor. All rights reserved.
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
 //
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
 
 import Foundation
 
-public class MenuItemElement: UIElement{
+public class MenuItemElement: UIElement {
     
     public var title: String? {
         accessibilityElement.value(forAttribute: .title)
     }
     
-    public func select() -> Bool{
-        guard accessibilityElement.perform(action: .press) else{
+    public func select() -> Bool {
+        guard accessibilityElement.perform(action: .press) else {
             return false
         }
         return true

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/SystemPrefs/AccessibilityPreferencesElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/SystemPrefs/AccessibilityPreferencesElement.swift
@@ -23,15 +23,15 @@
 
 import Foundation
 
-public class AccessibilityPreferencesElement: UIElement{
+public class AccessibilityPreferencesElement: UIElement {
     
-    public enum CategoryIdentifier{
+    public enum CategoryIdentifier {
         
         case display
         case zoom
         case voiceOver
         
-        public var rowTitle: String{
+        public var rowTitle: String {
             get{
                 switch self {
                 case .display:
@@ -46,46 +46,46 @@ public class AccessibilityPreferencesElement: UIElement{
         
     }
     
-    public var categoriesTable: TableElement?{
+    public var categoriesTable: TableElement? {
         return table(titled: "Accessibility features")
     }
     
-    public func selectDisplay(completion: @escaping (_ success: Bool) -> Void){
-        select(category: .display){
+    public func selectDisplay(completion: @escaping (_ success: Bool) -> Void) {
+        select(category: .display) {
             success in
             guard success else{
                 completion(false)
                 return
             }
-            self.wait(atMost: 1.0, for: { self.tabGroup?.tab(titled: "Display") != nil}){
+            self.wait(atMost: 1.0, for: { self.tabGroup?.tab(titled: "Display") != nil}) {
                 success in
                 completion(success)
             }
         }
     }
     
-    public func selectVoiceOver(completion: @escaping (_ success: Bool) -> Void){
-        select(category: .voiceOver){
+    public func selectVoiceOver(completion: @escaping (_ success: Bool) -> Void) {
+        select(category: .voiceOver) {
             success in
             guard success else{
                 completion(false)
                 return
             }
-            self.wait(atMost: 1.0, for: { self.checkbox(titled: "Enable VoiceOver") != nil}){
+            self.wait(atMost: 1.0, for: { self.checkbox(titled: "Enable VoiceOver") != nil}) {
                 success in
                 completion(success)
             }
         }
     }
     
-    public func selectZoom(completion: @escaping (_ success: Bool) -> Void){
-        select(category: .zoom){
+    public func selectZoom(completion: @escaping (_ success: Bool) -> Void) {
+        select(category: .zoom) {
             success in
-            guard success else{
+            guard success else {
                 completion(false)
                 return
             }
-            self.wait(atMost: 1.0, for: { self.checkbox(titled: "Use keyboard shortcuts to zoom") != nil}){
+            self.wait(atMost: 1.0, for: { self.checkbox(titled: "Use keyboard shortcuts to zoom") != nil}) {
                 success in
                 completion(success)
             }
@@ -93,14 +93,14 @@ public class AccessibilityPreferencesElement: UIElement{
         
     }
 
-    public func select(category identifier: CategoryIdentifier, completion: @escaping (_ success: Bool) -> Void){
-        wait(atMost: 1.0, for: { self.categoriesTable != nil }){
+    public func select(category identifier: CategoryIdentifier, completion: @escaping (_ success: Bool) -> Void) {
+        wait(atMost: 1.0, for: { self.categoriesTable != nil }) {
             success in
-            guard success else{
+            guard success else {
                 completion(false)
                 return
             }
-            guard let row = self.categoriesTable?.row(titled: identifier.rowTitle) else{
+            guard let row = self.categoriesTable?.row(titled: identifier.rowTitle) else {
                 completion(false)
                 return
             }
@@ -109,7 +109,7 @@ public class AccessibilityPreferencesElement: UIElement{
         }
     }
     
-    public func select(tabTitled title: String) -> Bool{
+    public func select(tabTitled title: String) -> Bool {
         return tabGroup?.select(tabTitled: title) ?? false
     }
     

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/SystemPrefs/SystemPreferencesElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/SystemPrefs/SystemPreferencesElement.swift
@@ -23,7 +23,7 @@
 
 import Foundation
 
-public class SystemPreferencesElement: ApplicationElement{
+public class SystemPreferencesElement: ApplicationElement {
     
     public init() {
         super.init(bundleIdentifier: "com.apple.systempreferences")
@@ -33,10 +33,10 @@ public class SystemPreferencesElement: ApplicationElement{
         fatalError("init(accessibilityElement:) has not been implemented")
     }
     
-    public enum PaneIdentifier{
+    public enum PaneIdentifier {
         case accessibility
         
-        public var buttonTitle: String{
+        public var buttonTitle: String {
             get{
                 switch self {
                 case .accessibility:
@@ -45,7 +45,7 @@ public class SystemPreferencesElement: ApplicationElement{
             }
         }
         
-        public var windowTitle: String{
+        public var windowTitle: String {
             get{
                 switch self {
                 case .accessibility:
@@ -55,46 +55,46 @@ public class SystemPreferencesElement: ApplicationElement{
         }
     }
     
-    public func showAccessibility(completion: @escaping (_ success: Bool, _ pane: AccessibilityPreferencesElement?) -> Void){
+    public func showAccessibility(completion: @escaping (_ success: Bool, _ pane: AccessibilityPreferencesElement?) -> Void) {
         return show(pane: .accessibility, completion: completion)
     }
     
-    public func show<ElementType: UIElement>(pane identifier: PaneIdentifier, completion: @escaping (_ success: Bool, _ pane: ElementType?) -> Void){
-        guard let window = mainWindow else{
+    public func show<ElementType: UIElement>(pane identifier: PaneIdentifier, completion: @escaping (_ success: Bool, _ pane: ElementType?) -> Void) {
+        guard let window = mainWindow else {
             completion(false, nil)
             return
         }
-        guard window.raise() else{
+        guard window.raise() else {
             completion(false, nil)
             return
         }
-        guard window.title != identifier.windowTitle else{
+        guard window.title != identifier.windowTitle else {
             completion(true, ElementType(accessibilityElement: window.accessibilityElement))
             return
         }
-        guard let showAllButton = window.toolbar?.button(titled: "Show All") else{
+        guard let showAllButton = window.toolbar?.button(titled: "Show All") else {
             completion(false, nil)
             return
         }
-        guard showAllButton.press() else{
+        guard showAllButton.press() else {
             completion(false, nil)
             return
         }
-        wait(atMost: 3.0, for: { window.title == "System Preferences" }){
+        wait(atMost: 3.0, for: { window.title == "System Preferences" }) {
             success in
-            guard success else{
+            guard success else {
                 completion(false, nil)
                 return
             }
-            guard let paneButton = window.button(titled: identifier.buttonTitle) else{
+            guard let paneButton = window.button(titled: identifier.buttonTitle) else {
                 completion(false, nil)
                 return
             }
-            guard paneButton.press() else{
+            guard paneButton.press() else {
                 completion(false, nil)
                 return
             }
-            self.wait(atMost: 3.0, for: { window.title == identifier.windowTitle }){
+            self.wait(atMost: 3.0, for: { window.title == identifier.windowTitle }) {
                 success in
                 completion(success, ElementType(accessibilityElement: window.accessibilityElement))
             }

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/Tables/CellElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/Tables/CellElement.swift
@@ -23,9 +23,9 @@
 
 import Foundation
 
-public class CellElement: UIElement{
+public class CellElement: UIElement {
     
-    public var text: String?{
+    public var text: String? {
         get{
             return label?.text
         }

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/Tables/RowElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/Tables/RowElement.swift
@@ -23,23 +23,23 @@
 
 import Foundation
 
-public class RowElement: UIElement{
+public class RowElement: UIElement {
     
-    public func select() -> Bool{
-        guard accessibilityElement.setValue(true, forAttribute: .selected) else{
+    public func select() -> Bool {
+        guard accessibilityElement.setValue(true, forAttribute: .selected) else {
             return false
         }
         return true
     }
     
-    public func cell(at index: Int) -> CellElement?{
-        guard let cells = accessibilityElement.children()?.filter({ $0.role == .cell }) else{
+    public func cell(at index: Int) -> CellElement? {
+        guard let cells = accessibilityElement.children()?.filter({ $0.role == .cell }) else {
             return nil
         }
-        guard index >= 0 else{
+        guard index >= 0 else {
             return nil
         }
-        guard index < cells.count else{
+        guard index < cells.count else {
             return nil
         }
         return CellElement(accessibilityElement: cells[index])

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/Tables/TableElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/Tables/TableElement.swift
@@ -23,19 +23,19 @@
 
 import Foundation
 
-public class TableElement: UIElement{
+public class TableElement: UIElement {
     
-    public func row(titled: String) -> RowElement?{
+    public func row(titled: String) -> RowElement? {
         for row in rows{
-            if row.cell(at: 0)?.text == titled{
+            if row.cell(at: 0)?.text == titled {
                 return row
             }
         }
         return nil
     }
     
-    public var rows: [RowElement]{
-        guard let accessibilityRows: [MorphicA11yUIElement] = accessibilityElement.values(forAttribute: .rows) else{
+    public var rows: [RowElement] {
+        guard let accessibilityRows: [MorphicA11yUIElement] = accessibilityElement.values(forAttribute: .rows) else {
             return []
         }
         return accessibilityRows.map{ RowElement(accessibilityElement: $0) }

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/UIElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/UIElement.swift
@@ -31,83 +31,83 @@ public class UIElement{
     
     var accessibilityElement: MorphicA11yUIElement!
     
-    public required init(accessibilityElement: MorphicA11yUIElement?){
+    public required init(accessibilityElement: MorphicA11yUIElement?) {
         self.accessibilityElement = accessibilityElement
     }
     
-    public func button(titled: String) -> ButtonElement?{
+    public func button(titled: String) -> ButtonElement? {
         return descendant(role: .button, title: titled)
     }
     
-    public func checkbox(titled: String) -> CheckboxElement?{
+    public func checkbox(titled: String) -> CheckboxElement? {
         return descendant(role: .checkBox, title: titled)
     }
     
-    public func table(titled: String) -> TableElement?{
+    public func table(titled: String) -> TableElement? {
         return descendant(role: .table, title: titled)
     }
     
-    public var label: LabelElement?{
+    public var label: LabelElement? {
         return descendant(role: .staticText)
     }
     
-    public var tabGroup: TabGroupElement?{
+    public var tabGroup: TabGroupElement? {
         return descendant(role: .tabGroup)
     }
     
-    public func popUpButton(titled: String) -> PopUpButtonElement?{
+    public func popUpButton(titled: String) -> PopUpButtonElement? {
         return descendant(role: .popUpButton, title: titled)
     }
     
-    public func firstPopupButton() -> PopUpButtonElement?{
+    public func firstPopupButton() -> PopUpButtonElement? {
         return descendant(role: .popUpButton)
     }
     
-    public func slider(titled: String) -> SliderElement?{
+    public func slider(titled: String) -> SliderElement? {
         return descendant(role: .slider, title: titled)
     }
     
-    public func firstSlider() -> SliderElement?{
+    public func firstSlider() -> SliderElement? {
         return descendant(role: .slider)
     }
     
-    public var menu: MenuElement?{
+    public var menu: MenuElement? {
         return descendant(role: .menu)
     }
     
-    private func descendant<ElementType: UIElement>(role: NSAccessibility.Role, title: String) -> ElementType?{
+    private func descendant<ElementType: UIElement>(role: NSAccessibility.Role, title: String) -> ElementType? {
         guard let accessibilityElement = accessibilityDescendant(role: role, title: title) else{
             return nil
         }
         return ElementType(accessibilityElement: accessibilityElement)
     }
     
-    private func descendant<ElementType: UIElement>(role: NSAccessibility.Role) -> ElementType?{
-        guard let accessibilityElement = accessibilityDescendant(role: role) else{
+    private func descendant<ElementType: UIElement>(role: NSAccessibility.Role) -> ElementType? {
+        guard let accessibilityElement = accessibilityDescendant(role: role) else {
             return nil
         }
         return ElementType(accessibilityElement: accessibilityElement)
     }
     
-    private func accessibilityDescendant(role: NSAccessibility.Role, title: String) -> MorphicA11yUIElement?{
-        guard let children = accessibilityElement.children() else{
+    private func accessibilityDescendant(role: NSAccessibility.Role, title: String) -> MorphicA11yUIElement? {
+        guard let children = accessibilityElement.children() else {
             return nil
         }
         var stack = children
         var i = 0
-        while i < stack.count{
+        while i < stack.count {
             let candidate = stack[i]
             if candidate.role == role{
-                if candidate.value(forAttribute: .title) == title || candidate.value(forAttribute: .description) == title{
+                if candidate.value(forAttribute: .title) == title || candidate.value(forAttribute: .description) == title {
                     return candidate
                 }
-                if let titleElement: MorphicA11yUIElement = candidate.value(forAttribute: .titleUIElement){
-                    if titleElement.value(forAttribute: .value) == title{
+                if let titleElement: MorphicA11yUIElement = candidate.value(forAttribute: .titleUIElement) {
+                    if titleElement.value(forAttribute: .value) == title {
                         return candidate
                     }
                 }
             }
-            if let children = candidate.children(){
+            if let children = candidate.children() {
                 stack.append(contentsOf: children)
             }
             i += 1
@@ -115,7 +115,7 @@ public class UIElement{
         return nil
     }
     
-    private func accessibilityDescendant(role: NSAccessibility.Role) -> MorphicA11yUIElement?{
+    private func accessibilityDescendant(role: NSAccessibility.Role) -> MorphicA11yUIElement? {
         guard let children = accessibilityElement.children() else{
             return nil
         }
@@ -123,10 +123,10 @@ public class UIElement{
         var i = 0
         while i < stack.count{
             let candidate = stack[i]
-            if candidate.role == role{
+            if candidate.role == role {
                 return candidate
             }
-            if let children = candidate.children(){
+            if let children = candidate.children() {
                 stack.append(contentsOf: children)
             }
             i += 1
@@ -134,13 +134,13 @@ public class UIElement{
         return nil
     }
     
-    public func wait(atMost: TimeInterval, for condition: @escaping () -> Bool, completion: @escaping (_ success: Bool) -> Void){
-        guard !condition() else{
+    public func wait(atMost: TimeInterval, for condition: @escaping () -> Bool, completion: @escaping (_ success: Bool) -> Void) {
+        guard !condition() else {
             completion(true)
             return
         }
         var checkTimer: Timer?
-        let timeoutTimer = Timer.scheduledTimer(withTimeInterval: atMost, repeats: false){
+        let timeoutTimer = Timer.scheduledTimer(withTimeInterval: atMost, repeats: false) {
             _ in
             checkTimer?.invalidate()
             completion(condition())
@@ -148,12 +148,12 @@ public class UIElement{
         var checkInterval: TimeInterval = 0.1
         var check: (() -> Void)!
         check = {
-            checkTimer = Timer.scheduledTimer(withTimeInterval: checkInterval, repeats: false){
+            checkTimer = Timer.scheduledTimer(withTimeInterval: checkInterval, repeats: false) {
                 _ in
-                if condition(){
+                if condition() {
                     timeoutTimer.invalidate()
                     completion(true)
-                }else{
+                } else {
                     checkInterval *= 2
                     check()
                 }
@@ -162,8 +162,8 @@ public class UIElement{
         check()
     }
     
-    public func perform(action: Action, completion: @escaping (_ success: Bool, _ nextTarget: UIElement?) -> Void){
-        switch action{
+    public func perform(action: Action, completion: @escaping (_ success: Bool, _ nextTarget: UIElement?) -> Void) {
+        switch action {
         case .check(let title, let checked):
             let checkbox = self.checkbox(titled: title)
             let success = checkbox?.setChecked(checked) ?? false
@@ -177,11 +177,11 @@ public class UIElement{
         }
     }
     
-    public enum Action{
+    public enum Action {
         case launch(bundleIdentifier: String)
         case show(identifier: String)
         case check(checkboxTitle: String, checked: Bool)
         case press(buttonTitle: String)
     }
-    
+
 }

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/Windows/ToolbarElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/Windows/ToolbarElement.swift
@@ -23,6 +23,6 @@
 
 import Foundation
 
-public class ToolbarElement: UIElement{
+public class ToolbarElement: UIElement {
     
 }

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/Windows/WindowElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/Windows/WindowElement.swift
@@ -23,22 +23,22 @@
 
 import Foundation
 
-public class WindowElement: UIElement{
+public class WindowElement: UIElement {
     
-    public var toolbar: ToolbarElement?{
+    public var toolbar: ToolbarElement? {
         get{
-            guard let toolbar = accessibilityElement.children()?.firstAndOnly(where: { $0.role == .toolbar }) else{
+            guard let toolbar = accessibilityElement.children()?.firstAndOnly(where: { $0.role == .toolbar }) else {
                 return nil
             }
             return ToolbarElement(accessibilityElement: toolbar)
         }
     }
     
-    public func raise() -> Bool{
+    public func raise() -> Bool {
         return accessibilityElement.perform(action: .raise)
     }
     
-    public var title: String?{
+    public var title: String? {
         get{
             return accessibilityElement.value(forAttribute: .title)
         }

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/WorkspaceElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/WorkspaceElement.swift
@@ -27,11 +27,11 @@ import OSLog
 
 private var logger = OSLog(subsystem: "MorphicSettings", category: "WorkspaceElement")
 
-public class WorkspaceElement: UIElement{
+public class WorkspaceElement: UIElement {
     
     public static let shared = WorkspaceElement(accessibilityElement: nil)
     
-    public override func perform(action: Action, completion: @escaping (_ success: Bool, _ nextTarget: UIElement?) -> Void){
+    public override func perform(action: Action, completion: @escaping (_ success: Bool, _ nextTarget: UIElement?) -> Void) {
         switch action {
         case .launch(let bundleIdentifier):
             let app = ApplicationElement.from(bundleIdentifier: bundleIdentifier)
@@ -46,27 +46,27 @@ public class WorkspaceElement: UIElement{
     
     public var launchedApplications = [ApplicationElement]()
     
-    public func closeLaunchedApplications(){
-        for application in launchedApplications{
-            if !application.terminate(){
+    public func closeLaunchedApplications() {
+        for application in launchedApplications {
+            if !application.terminate() {
                 os_log(.error, log: logger, "Failed to terminate application %{public}s", application.bundleIdentifier)
             }
         }
         launchedApplications = []
     }
     
-    public func send(keyCode: Int, down: Bool) -> Bool{
+    public func send(keyCode: Int, down: Bool) -> Bool {
         return KeyEvents.sendSystemWideKeyChar(CGCharCode(0), keyCode: CGKeyCode(keyCode), isDown: down)
     }
     
-    public func send(keyCodes: [Int]) -> Bool{
-        for code in keyCodes{
-            if !send(keyCode: code, down: true){
+    public func send(keyCodes: [Int]) -> Bool {
+        for code in keyCodes {
+            if !send(keyCode: code, down: true) {
                 return false
             }
         }
-        for code in keyCodes{
-            if !send(keyCode: code, down: false){
+        for code in keyCodes {
+            if !send(keyCode: code, down: false) {
                 return false
             }
         }

--- a/MorphicSettings/MorphicSettings/Audio.swift
+++ b/MorphicSettings/MorphicSettings/Audio.swift
@@ -27,24 +27,24 @@ import OSLog
 
 private let logger = OSLog(subsystem: "MorphicSettings", category: "Audio")
 
-public class AudioOutput{
+public class AudioOutput {
     
-    init(id: UInt32){
+    init(id: UInt32) {
         self.id = id
     }
     
     private var id: UInt32
     
     public static var main: AudioOutput? = {
-        if let id = MorphicAudio.getDefaultAudioDeviceId(){
+        if let id = MorphicAudio.getDefaultAudioDeviceId() {
             return AudioOutput(id: id)
         }
         return nil
     }()
     
     public var isMuted: Bool{
-        get{
-            if let muted = MorphicAudio.getMuteState(for: id){
+        get {
+            if let muted = MorphicAudio.getMuteState(for: id) {
                 return muted
             }
             os_log(.error, log: logger, "Failed to get mute state, assuming false")
@@ -52,19 +52,19 @@ public class AudioOutput{
         }
     }
     
-    public func setMuted(_ muted: Bool) -> Bool{
-        do{
+    public func setMuted(_ muted: Bool) -> Bool {
+        do {
             try MorphicAudio.setMuteState(for: id, muteState: muted)
             return true
-        }catch{
+        } catch {
             os_log(.error, log: logger, "Exception while setting mute state: %{public}s", error.localizedDescription)
             return false
         }
     }
     
-    public var volume: Double{
-        get{
-            if let value = MorphicAudio.getVolume(for: id){
+    public var volume: Double {
+        get {
+            if let value = MorphicAudio.getVolume(for: id) {
                 return Double(value)
             }
             os_log(.error, log: logger, "Failed to get volume, assuming 0.0")
@@ -72,11 +72,11 @@ public class AudioOutput{
         }
     }
     
-    public func setVolume(_ value: Double) -> Bool{
-        do{
+    public func setVolume(_ value: Double) -> Bool {
+        do {
             try MorphicAudio.setVolume(for: id, volume: Float(value))
             return true
-        }catch{
+        } catch {
             os_log(.error, log: logger, "Exception while setting volume: %{public}s", error.localizedDescription)
             return false
         }

--- a/MorphicSettings/MorphicSettings/Automations/AccessibilityUIAutomation.swift
+++ b/MorphicSettings/MorphicSettings/Automations/AccessibilityUIAutomation.swift
@@ -28,7 +28,7 @@ import OSLog
 private let logger = OSLog(subsystem: "MorphicSettings", category: "AccessibilityUIAutomation")
 
 
-public class AccessibilityUIAutomation: UIAutomation{
+public class AccessibilityUIAutomation: UIAutomation {
     
     public required init() {
     }
@@ -37,16 +37,16 @@ public class AccessibilityUIAutomation: UIAutomation{
         fatalError("Not implemented")
     }
         
-    public func showAccessibilityPreferences(completion: @escaping (_ accessibility: AccessibilityPreferencesElement?) -> Void){
+    public func showAccessibilityPreferences(completion: @escaping (_ accessibility: AccessibilityPreferencesElement?) -> Void) {
         let app = SystemPreferencesElement()
-        app.open{
+        app.open {
             success in
             guard success else {
                 os_log(.error, log: logger, "Failed to open system preferences")
                 completion(nil)
                 return
             }
-            app.showAccessibility{
+            app.showAccessibility {
                 success, accessibility in
                 guard success else {
                     os_log(.error, log: logger, "Failed to show Accessibility pane")
@@ -58,21 +58,21 @@ public class AccessibilityUIAutomation: UIAutomation{
         }
     }
     
-    public func showAccessibilityDisplayPreferences(tab: String, completion: @escaping (_ accessibility: AccessibilityPreferencesElement?) -> Void){
-        showAccessibilityPreferences{
+    public func showAccessibilityDisplayPreferences(tab: String, completion: @escaping (_ accessibility: AccessibilityPreferencesElement?) -> Void) {
+        showAccessibilityPreferences {
             accessibility in
-            guard let accessibility = accessibility else{
+            guard let accessibility = accessibility else {
                 completion(nil)
                 return
             }
-            accessibility.selectDisplay{
+            accessibility.selectDisplay {
                 success in
-                guard success else{
+                guard success else {
                     os_log(.error, log: logger, "Failed to select Display category")
                     completion(nil)
                     return
                 }
-                guard accessibility.select(tabTitled: tab) else{
+                guard accessibility.select(tabTitled: tab) else {
                     os_log(.error, log: logger, "Failed to select Display tab")
                     completion(nil)
                     return
@@ -83,13 +83,13 @@ public class AccessibilityUIAutomation: UIAutomation{
     }
     
     public func showAccessibilityVoiceOverPreferences(completion: @escaping (_ accessibility: AccessibilityPreferencesElement?) -> Void){
-        showAccessibilityPreferences{
+        showAccessibilityPreferences {
             accessibility in
-            guard let accessibility = accessibility else{
+            guard let accessibility = accessibility else {
                 completion(nil)
                 return
             }
-            accessibility.selectVoiceOver{
+            accessibility.selectVoiceOver {
                 success in
                 guard success else{
                     os_log(.error, log: logger, "Failed to select VoiceOver category")
@@ -101,16 +101,16 @@ public class AccessibilityUIAutomation: UIAutomation{
         }
     }
     
-    public func showAccessibilityZoomPreferences(completion: @escaping (_ accessibility: AccessibilityPreferencesElement?) -> Void){
-        showAccessibilityPreferences{
+    public func showAccessibilityZoomPreferences(completion: @escaping (_ accessibility: AccessibilityPreferencesElement?) -> Void) {
+        showAccessibilityPreferences {
             accessibility in
-            guard let accessibility = accessibility else{
+            guard let accessibility = accessibility else {
                 completion(nil)
                 return
             }
-            accessibility.selectZoom{
+            accessibility.selectZoom {
                 success in
-                guard success else{
+                guard success else {
                     os_log(.error, log: logger, "Failed to select Zoom category")
                     completion(nil)
                     return

--- a/MorphicSettings/MorphicSettings/Automations/DisplayUIAutomations.swift
+++ b/MorphicSettings/MorphicSettings/Automations/DisplayUIAutomations.swift
@@ -27,29 +27,29 @@ import OSLog
 
 private let logger = OSLog(subsystem: "MorphicSettings", category: "DisplayUIAutomations")
 
-public class DisplayCheckboxUIAutomation: AccessibilityUIAutomation{
+public class DisplayCheckboxUIAutomation: AccessibilityUIAutomation {
     
     var tabTitle: String! { nil }
     var checkboxTitle: String! { nil }
 
     public override func apply(_ value: Interoperable?, completion: @escaping (Bool) -> Void) {
-        guard let checked = value as? Bool else{
+        guard let checked = value as? Bool else {
             os_log(.error, log: logger, "Passed non-boolean value to checkbox")
             completion(false)
             return
         }
-        showAccessibilityDisplayPreferences(tab: self.tabTitle){
+        showAccessibilityDisplayPreferences(tab: self.tabTitle) {
             accessibility in
-            guard let accessibility = accessibility else{
+            guard let accessibility = accessibility else {
                 completion(false)
                 return
             }
-            guard let checkbox = accessibility.checkbox(titled: self.checkboxTitle) else{
+            guard let checkbox = accessibility.checkbox(titled: self.checkboxTitle) else {
                 os_log(.error, log: logger, "Failed to find checkbox")
                 completion(false)
                 return
             }
-            guard checkbox.setChecked(checked) else{
+            guard checkbox.setChecked(checked) else {
                 os_log(.error, log: logger, "Failed to press checkbox")
                 completion(false)
                 return
@@ -60,33 +60,33 @@ public class DisplayCheckboxUIAutomation: AccessibilityUIAutomation{
     
 }
 
-public class DisplaySliderUIAutomation: AccessibilityUIAutomation{
+public class DisplaySliderUIAutomation: AccessibilityUIAutomation {
     
     var tabTitle: String! { nil }
     var sliderTitle: String! { nil }
 
     public override func apply(_ value: Interoperable?, completion: @escaping (Bool) -> Void) {
-        if let intValue = value as? Int{
+        if let intValue = value as? Int {
             apply(Double(intValue), completion: completion)
             return
         }
-        guard let value = value as? Double else{
+        guard let value = value as? Double else {
             os_log(.error, log: logger, "Passed non-double value to slider")
             completion(false)
             return
         }
-        showAccessibilityDisplayPreferences(tab: self.tabTitle){
+        showAccessibilityDisplayPreferences(tab: self.tabTitle) {
             accessibility in
-            guard let accessibility = accessibility else{
+            guard let accessibility = accessibility else {
                 completion(false)
                 return
             }
-            guard let slider = accessibility.slider(titled: self.sliderTitle) else{
+            guard let slider = accessibility.slider(titled: self.sliderTitle) else {
                 os_log(.error, log: logger, "Failed to find slider")
                 completion(false)
                 return
             }
-            guard slider.setValue(value) else{
+            guard slider.setValue(value) else {
                 os_log(.error, log: logger, "Failed to update slider value")
                 completion(false)
                 return
@@ -97,33 +97,33 @@ public class DisplaySliderUIAutomation: AccessibilityUIAutomation{
     
 }
 
-public class ContrastUIAutomation: AccessibilityUIAutomation{
+public class ContrastUIAutomation: AccessibilityUIAutomation {
     
     public override func apply(_ value: Interoperable?, completion: @escaping (Bool) -> Void) {
-        guard let checked = value as? Bool else{
+        guard let checked = value as? Bool else {
             os_log(.error, log: logger, "Passed non-boolean value to contrast")
             completion(false)
             return
         }
-        showAccessibilityDisplayPreferences(tab: "Display"){
+        showAccessibilityDisplayPreferences(tab: "Display") {
             accessibility in
-            guard let accessibility = accessibility else{
+            guard let accessibility = accessibility else {
                 completion(false)
                 return
             }
-            guard let checkbox = accessibility.checkbox(titled: "Increase contrast") else{
+            guard let checkbox = accessibility.checkbox(titled: "Increase contrast") else {
                 os_log(.error, log: logger, "Failed to find contrast checkbox")
                 completion(false)
                 return
             }
-            guard checkbox.setChecked(checked) else{
+            guard checkbox.setChecked(checked) else {
                 os_log(.error, log: logger, "Failed to press contrast checkbox")
                 completion(false)
                 return
             }
-            if !checked{
-                if let transparencyCheckbox = accessibility.checkbox(titled: "Reduce transparency"){
-                    if !transparencyCheckbox.uncheck(){
+            if !checked {
+                if let transparencyCheckbox = accessibility.checkbox(titled: "Reduce transparency") {
+                    if !transparencyCheckbox.uncheck() {
                         os_log(.info, log: logger, "Failed to uncheck reduce transparency when turning off high contrast")
                     }
                 }
@@ -134,7 +134,7 @@ public class ContrastUIAutomation: AccessibilityUIAutomation{
     
 }
 
-public class DisplayPopupButtonUIAutomation: AccessibilityUIAutomation{
+public class DisplayPopupButtonUIAutomation: AccessibilityUIAutomation {
     
     var tabTitle: String! { nil }
     var buttonTitle: String! { nil }
@@ -142,30 +142,30 @@ public class DisplayPopupButtonUIAutomation: AccessibilityUIAutomation{
     var optionTitles: [Int: String]! { nil }
     
     public override func apply(_ value: Interoperable?, completion: @escaping (Bool) -> Void) {
-        guard let value = value as? Int else{
+        guard let value = value as? Int else {
             os_log(.error, log: logger, "Passed non-int value to popup")
             completion(false)
             return
         }
-        guard let stringValue = optionTitles[value] else{
+        guard let stringValue = optionTitles[value] else {
             os_log(.error, log: logger, "Passed invalid int value to popup")
             completion(false)
             return
         }
-        showAccessibilityDisplayPreferences(tab: tabTitle){
+        showAccessibilityDisplayPreferences(tab: tabTitle) {
             accessibility in
-            guard let accessibility = accessibility else{
+            guard let accessibility = accessibility else {
                 completion(false)
                 return
             }
-            guard let button = accessibility.popUpButton(titled: self.buttonTitle) else{
+            guard let button = accessibility.popUpButton(titled: self.buttonTitle) else {
                 os_log(.error, log: logger, "Failed to find popup button")
                 completion(false)
                 return
             }
-            button.setValue(stringValue){
+            button.setValue(stringValue) {
                 success in
-                guard success else{
+                guard success else {
                     os_log(.error, log: logger, "Failed to set popup button value")
                     completion(false)
                     return
@@ -178,56 +178,56 @@ public class DisplayPopupButtonUIAutomation: AccessibilityUIAutomation{
     
 }
 
-public class InvertColorsUIAutomation: DisplayCheckboxUIAutomation{
+public class InvertColorsUIAutomation: DisplayCheckboxUIAutomation {
     
     override var tabTitle: String! { "Display" }
     override var checkboxTitle: String! { "Invert colors" }
     
 }
 
-public class InvertClassicUIAutomation: DisplayCheckboxUIAutomation{
+public class InvertClassicUIAutomation: DisplayCheckboxUIAutomation {
     
     override var tabTitle: String! { "Display" }
     override var checkboxTitle: String! { "Classic Invert" }
     
 }
 
-public class ReduceMotionUIAutomation: DisplayCheckboxUIAutomation{
+public class ReduceMotionUIAutomation: DisplayCheckboxUIAutomation {
     
     override var tabTitle: String! { "Display" }
     override var checkboxTitle: String! { "Reduce motion" }
     
 }
 
-public class ReduceTransparencyUIAutomation: DisplayCheckboxUIAutomation{
+public class ReduceTransparencyUIAutomation: DisplayCheckboxUIAutomation {
     
     override var tabTitle: String! { "Display" }
     override var checkboxTitle: String! { "Reduce transparency" }
     
 }
 
-public class DifferentiateWithoutColorUIAutomation: DisplayCheckboxUIAutomation{
+public class DifferentiateWithoutColorUIAutomation: DisplayCheckboxUIAutomation {
     
     override var tabTitle: String! { "Display" }
     override var checkboxTitle: String! { "Differentiate without color" }
     
 }
 
-public class CursorShakeUIAutomation: DisplayCheckboxUIAutomation{
+public class CursorShakeUIAutomation: DisplayCheckboxUIAutomation {
     
     override var tabTitle: String! { "Cursor" }
     override var checkboxTitle: String! { "Shake mouse pointer to locate" }
     
 }
 
-public class CursorSizeUIAutomation: DisplaySliderUIAutomation{
+public class CursorSizeUIAutomation: DisplaySliderUIAutomation {
     
     override var tabTitle: String! { "Cursor" }
     override var sliderTitle: String! { "Cursor size:" }
     
 }
 
-public class ColorFilterEnabledAutomation: DisplayCheckboxUIAutomation{
+public class ColorFilterEnabledAutomation: DisplayCheckboxUIAutomation {
     
     override var tabTitle: String! { "Color Filters" }
     override var checkboxTitle: String! { "Enable Color Filters" }
@@ -235,8 +235,7 @@ public class ColorFilterEnabledAutomation: DisplayCheckboxUIAutomation{
 }
 
 // Type Popup isn't properly labeled
-public class ColorFilterTypeAutomation: AccessibilityUIAutomation{
-
+public class ColorFilterTypeAutomation: AccessibilityUIAutomation {
     
     var optionTitles: [Int : String]! {
         [
@@ -247,31 +246,32 @@ public class ColorFilterTypeAutomation: AccessibilityUIAutomation{
             16: "Color Tint"
         ]
     }
+    
     public override func apply(_ value: Interoperable?, completion: @escaping (Bool) -> Void) {
-        guard let value = value as? Int else{
+        guard let value = value as? Int else {
             os_log(.error, log: logger, "Passed non-int value to popup")
             completion(false)
             return
         }
-        guard let stringValue = optionTitles[value] else{
+        guard let stringValue = optionTitles[value] else {
             os_log(.error, log: logger, "Passed invalid int value to popup")
             completion(false)
             return
         }
-        showAccessibilityDisplayPreferences(tab: "Color Filters"){
+        showAccessibilityDisplayPreferences(tab: "Color Filters") {
             accessibility in
-            guard let accessibility = accessibility else{
+            guard let accessibility = accessibility else {
                 completion(false)
                 return
             }
-            guard let button = accessibility.firstPopupButton() else{
+            guard let button = accessibility.firstPopupButton() else {
                 os_log(.error, log: logger, "Failed to find popup button")
                 completion(false)
                 return
             }
-            button.setValue(stringValue){
+            button.setValue(stringValue) {
                 success in
-                guard success else{
+                guard success else {
                     os_log(.error, log: logger, "Failed to set popup button value")
                     completion(false)
                     return
@@ -285,30 +285,30 @@ public class ColorFilterTypeAutomation: AccessibilityUIAutomation{
 }
 
 // Intensity Slider isn't properly labeled
-class ColorFilterIntensityUIAutomation: AccessibilityUIAutomation{
+class ColorFilterIntensityUIAutomation: AccessibilityUIAutomation {
 
     public override func apply(_ value: Interoperable?, completion: @escaping (Bool) -> Void) {
-        if let intValue = value as? Int{
+        if let intValue = value as? Int {
             apply(Double(intValue), completion: completion)
             return
         }
-        guard let value = value as? Double else{
+        guard let value = value as? Double else {
             os_log(.error, log: logger, "Passed non-double value to slider")
             completion(false)
             return
         }
-        showAccessibilityDisplayPreferences(tab: "Color Filters"){
+        showAccessibilityDisplayPreferences(tab: "Color Filters") {
             accessibility in
-            guard let accessibility = accessibility else{
+            guard let accessibility = accessibility else {
                 completion(false)
                 return
             }
-            guard let slider = accessibility.firstSlider() else{
+            guard let slider = accessibility.firstSlider() else {
                 os_log(.error, log: logger, "Failed to find slider")
                 completion(false)
                 return
             }
-            guard slider.setValue(value) else{
+            guard slider.setValue(value) else {
                 os_log(.error, log: logger, "Failed to update slider value")
                 completion(false)
                 return

--- a/MorphicSettings/MorphicSettings/Automations/UIAutomation.swift
+++ b/MorphicSettings/MorphicSettings/Automations/UIAutomation.swift
@@ -24,7 +24,7 @@
 import Foundation
 import MorphicCore
 
-public protocol UIAutomation{
+public protocol UIAutomation {
     
     init()
     

--- a/MorphicSettings/MorphicSettings/Automations/VoiceOverUIAutomations.swift
+++ b/MorphicSettings/MorphicSettings/Automations/VoiceOverUIAutomations.swift
@@ -27,27 +27,26 @@ import OSLog
 
 private let logger = OSLog(subsystem: "MorphicSettings", category: "VoiceOverUIAutomation")
 
-
-public class VoiceOverUIAutomation: AccessibilityUIAutomation{
+public class VoiceOverUIAutomation: AccessibilityUIAutomation {
     
     public override func apply(_ value: Interoperable?, completion: @escaping (Bool) -> Void) {
-        guard let checked = value as? Bool else{
+        guard let checked = value as? Bool else {
             os_log(.error, log: logger, "Passed non-boolean value")
             completion(false)
             return
         }
-        showAccessibilityVoiceOverPreferences{
+        showAccessibilityVoiceOverPreferences {
             accessibility in
-            guard let accessibility = accessibility else{
+            guard let accessibility = accessibility else {
                 completion(false)
                 return
             }
-            guard let checkbox = accessibility.checkbox(titled: "Enable VoiceOver") else{
+            guard let checkbox = accessibility.checkbox(titled: "Enable VoiceOver") else {
                 os_log(.error, log: logger, "Failed to find VoiceOver checkbox")
                 completion(false)
                 return
             }
-            guard checkbox.setChecked(checked) else{
+            guard checkbox.setChecked(checked) else {
                 os_log(.error, log: logger, "Failed to press VoiceOver checkbox")
                 completion(false)
                 return
@@ -55,7 +54,7 @@ public class VoiceOverUIAutomation: AccessibilityUIAutomation{
             accessibility.wait(atMost: 5.0, for: {
                 let running = NSWorkspace.shared.runningApplications.contains(where: { $0.bundleIdentifier == "com.apple.VoiceOver" })
                 return running == checked
-            }){
+            }) {
                 success in
                 completion(success)
             }

--- a/MorphicSettings/MorphicSettings/Automations/ZoomUIAutomations.swift
+++ b/MorphicSettings/MorphicSettings/Automations/ZoomUIAutomations.swift
@@ -28,29 +28,28 @@ import Carbon.HIToolbox
 
 private let logger = OSLog(subsystem: "MorphicSettings", category: "ZoomUIAutomations")
 
-
-public class ZoomCheckboxUIAutomation: AccessibilityUIAutomation{
+public class ZoomCheckboxUIAutomation: AccessibilityUIAutomation {
     
     var checkboxTitle: String! { nil }
     
     public override func apply(_ value: Interoperable?, completion: @escaping (Bool) -> Void) {
-        guard let checked = value as? Bool else{
+        guard let checked = value as? Bool else {
             os_log(.error, log: logger, "Passed non-boolean value")
             completion(false)
             return
         }
-        showAccessibilityZoomPreferences{
+        showAccessibilityZoomPreferences {
             accessibility in
             guard let accessibility = accessibility else{
                 completion(false)
                 return
             }
-            guard let checkbox = accessibility.checkbox(titled: self.checkboxTitle) else{
+            guard let checkbox = accessibility.checkbox(titled: self.checkboxTitle) else {
                 os_log(.error, log: logger, "Failed to find checkbox")
                 completion(false)
                 return
             }
-            guard checkbox.setChecked(checked) else{
+            guard checkbox.setChecked(checked) else {
                 os_log(.error, log: logger, "Failed to check checkbox")
                 completion(false)
                 return
@@ -69,30 +68,30 @@ public class ZoomPopupButtonUIAutomation: AccessibilityUIAutomation{
     var optionTitles: [Int: String]! { nil }
     
     public override func apply(_ value: Interoperable?, completion: @escaping (Bool) -> Void) {
-        guard let value = value as? Int else{
+        guard let value = value as? Int else {
             os_log(.error, log: logger, "Passed non-int value to popup")
             completion(false)
             return
         }
-        guard let stringValue = optionTitles[value] else{
+        guard let stringValue = optionTitles[value] else {
             os_log(.error, log: logger, "Passed invalid int value to popup")
             completion(false)
             return
         }
-        showAccessibilityZoomPreferences{
+        showAccessibilityZoomPreferences {
             accessibility in
-            guard let accessibility = accessibility else{
+            guard let accessibility = accessibility else {
                 completion(false)
                 return
             }
-            guard let button = accessibility.popUpButton(titled: self.buttonTitle) else{
+            guard let button = accessibility.popUpButton(titled: self.buttonTitle) else {
                 os_log(.error, log: logger, "Failed to find popup button")
                 completion(false)
                 return
             }
-            button.setValue(stringValue){
+            button.setValue(stringValue) {
                 success in
-                guard success else{
+                guard success else {
                     os_log(.error, log: logger, "Failed to set popup button value")
                     completion(false)
                     return
@@ -106,45 +105,45 @@ public class ZoomPopupButtonUIAutomation: AccessibilityUIAutomation{
 }
 
 
-public class ZoomEnabledUIAutomation: AccessibilityUIAutomation{
+public class ZoomEnabledUIAutomation: AccessibilityUIAutomation {
     
     public override func apply(_ value: Interoperable?, completion: @escaping (Bool) -> Void) {
-        guard let checked = value as? Bool else{
+        guard let checked = value as? Bool else {
             os_log(.error, log: logger, "Passed non-boolean value")
             completion(false)
             return
         }
-        showAccessibilityZoomPreferences{
+        showAccessibilityZoomPreferences {
             accessibility in
-            guard let accessibility = accessibility else{
+            guard let accessibility = accessibility else {
                 completion(false)
                 return
             }
-            guard let checkbox = accessibility.checkbox(titled: "Use keyboard shortcuts to zoom") else{
+            guard let checkbox = accessibility.checkbox(titled: "Use keyboard shortcuts to zoom") else {
                 os_log(.error, log: logger, "Failed to find zoom keyboard shortcuts checkbox")
                 completion(false)
                 return
             }
-            guard checkbox.check() else{
+            guard checkbox.check() else {
                 os_log(.error, log: logger, "Failed to enable zoom keyboard shortcuts checkbox")
                 completion(false)
                 return
             }
-            guard let defaults = UserDefaults(suiteName: "com.apple.universalaccess") else{
+            guard let defaults = UserDefaults(suiteName: "com.apple.universalaccess") else {
                 os_log(.error, log: logger, "Failed to load defaults to determine current zoom level")
                 completion(false)
                 return
             }
-            guard checked != defaults.bool(forKey: "closeViewZoomedIn") else{
+            guard checked != defaults.bool(forKey: "closeViewZoomedIn") else {
                 completion(true)
                 return
             }
-            guard WorkspaceElement.shared.send(keyCodes: [kVK_Command, kVK_Option, kVK_ANSI_8]) else{
+            guard WorkspaceElement.shared.send(keyCodes: [kVK_Command, kVK_Option, kVK_ANSI_8]) else {
                 os_log(.error, log: logger, "Failed to send key shortcut")
                 completion(false)
                 return
             }
-            accessibility.wait(atMost: 5.0, for: { checked == defaults.bool(forKey: "closeViewZoomedIn") }){
+            accessibility.wait(atMost: 5.0, for: { checked == defaults.bool(forKey: "closeViewZoomedIn") }) {
                 success in
                 completion(success)
             }
@@ -154,25 +153,25 @@ public class ZoomEnabledUIAutomation: AccessibilityUIAutomation{
     
 }
 
-public class ScrollToZoomEnabledUIAutomation: ZoomCheckboxUIAutomation{
+public class ScrollToZoomEnabledUIAutomation: ZoomCheckboxUIAutomation {
     
     override var checkboxTitle: String! { "Use scroll gesture with modifier keys to zoom:" }
     
 }
 
-public class HoverTextEnabledUIAutomation: ZoomCheckboxUIAutomation{
+public class HoverTextEnabledUIAutomation: ZoomCheckboxUIAutomation {
     
     override var checkboxTitle: String! { "Enable Hover Text" }
     
 }
 
-public class TouchbarZoomEnabledUIAutomation: ZoomCheckboxUIAutomation{
+public class TouchbarZoomEnabledUIAutomation: ZoomCheckboxUIAutomation {
     
     override var checkboxTitle: String! { "Enable Touch Bar zoom" }
     
 }
 
-public class ZoomStyleUIAutomation: ZoomPopupButtonUIAutomation{
+public class ZoomStyleUIAutomation: ZoomPopupButtonUIAutomation {
     
     override var buttonTitle: String! { "Zoom style:" }
     

--- a/MorphicSettings/MorphicSettings/CaptureSession.swift
+++ b/MorphicSettings/MorphicSettings/CaptureSession.swift
@@ -27,15 +27,14 @@ import OSLog
 
 private let logger = OSLog(subsystem: "MorphicSettings", category: "CaptureSession")
 
-
 /// Capture many values into a `Preferences` object
-public class CaptureSession{
+public class CaptureSession {
  
     /// Create a capture session for the given settings manager and preferences target
     ///
     /// The settings manager will be used to fetch `Setting` information and the preferences will
     /// be modified with the results of the capture upon calling `run()`
-    public init(settingsManager: SettingsManager, preferences: Preferences){
+    public init(settingsManager: SettingsManager, preferences: Preferences) {
         self.settingsManager = settingsManager
         self.preferences = preferences
         keys = [Preferences.Key]()
@@ -57,9 +56,9 @@ public class CaptureSession{
     public var keys: [Preferences.Key]
     
     /// Add every single known setting to `keys` so they'll all be captured
-    public func addAllSolutions(){
-        for solution in settingsManager.solutions{
-            for setting in solution.settings{
+    public func addAllSolutions() {
+        for solution in settingsManager.solutions {
+            for setting in solution.settings {
                 let key = Preferences.Key(solution: solution.identifier, preference: setting.name)
                 keys.append(key)
             }
@@ -75,36 +74,36 @@ public class CaptureSession{
     ///
     /// - parameters:
     ///   - completion: Called when the run is done
-    public func run(completion: @escaping () -> Void){
-        guard keyQueue == nil else{
+    public func run(completion: @escaping () -> Void) {
+        guard keyQueue == nil else {
             return
         }
         keyQueue = keys.reversed()
         captureNextKey(completion: completion)
     }
     
-    private func captureNextKey(completion: @escaping () -> Void){
+    private func captureNextKey(completion: @escaping () -> Void) {
         guard keyQueue.count > 0 else{
             keyQueue = nil
             completion()
             return
         }
         let key = keyQueue.removeLast()
-        guard let setting = settingsManager.setting(for: key) else{
+        guard let setting = settingsManager.setting(for: key) else {
             os_log(.info, log: logger, "Failed to find setting for %{public}s.%{public}s", key.solution, key.preference)
             captureNextKey(completion: completion)
             return
         }
-        guard let handler = setting.createHandler() else{
+        guard let handler = setting.createHandler() else {
             os_log(.info, log: logger, "Failed create handler for %{public}s.%{public}s", key.solution, key.preference)
             captureNextKey(completion: completion)
             return
         }
         handler.read{
             result in
-            switch result{
+            switch result {
             case .succeeded(let value):
-                if self.captureDefaultValues || !setting.isDefault(value){
+                if self.captureDefaultValues || !setting.isDefault(value) {
                     self.preferences.set(value, for: key)
                 }else{
                     self.preferences.remove(key: key)

--- a/MorphicSettings/MorphicSettings/ClientSettingHandler.swift
+++ b/MorphicSettings/MorphicSettings/ClientSettingHandler.swift
@@ -25,19 +25,19 @@ import Foundation
 import MorphicCore
 
 /// Base class for client handlers that run custom code specific to the setting
-public class ClientSettingHandler: SettingHandler{
+public class ClientSettingHandler: SettingHandler {
     
     /// Factory method for creating a client setting handler
     ///
     /// Types are registered via `register(type:for:)`
     ///
     /// - parameter setting: The setting for which a handler should be created
-    public static func create(for setting: Setting) -> ClientSettingHandler?{
-        guard let description = setting.handlerDescription as? Description else{
+    public static func create(for setting: Setting) -> ClientSettingHandler? {
+        guard let description = setting.handlerDescription as? Description else {
             return nil
         }
         let key = Preferences.Key(solution: description.solution, preference: description.preference)
-        guard let type = handlerTypesByKey[key] else{
+        guard let type = handlerTypesByKey[key] else {
             return nil
         }
         return type.init(setting: setting)
@@ -50,7 +50,7 @@ public class ClientSettingHandler: SettingHandler{
     /// - parameters:
     ///   - type: The `ClientSettingHandler` subclass to use for the given key
     ///   - key: The key that identifies when to use the given type
-    public static func register(type: ClientSettingHandler.Type, for key: Preferences.Key){
+    public static func register(type: ClientSettingHandler.Type, for key: Preferences.Key) {
         handlerTypesByKey[key] = type
     }
     
@@ -58,14 +58,14 @@ public class ClientSettingHandler: SettingHandler{
     private static var handlerTypesByKey = [Preferences.Key: ClientSettingHandler.Type]()
     
     /// The properly typed description for this handler
-    private var description: Description{
+    private var description: Description {
         return setting.handlerDescription as! Description
     }
     
     /// Data model describing the properites for a client setting handler
-    public struct Description: SettingHandlerDescription{
+    public struct Description: SettingHandlerDescription {
         
-        public var type: Setting.HandlerType{
+        public var type: Setting.HandlerType {
             return .client
         }
 

--- a/MorphicSettings/MorphicSettings/DefaultsReadUIWriteSettingHandler.swift
+++ b/MorphicSettings/MorphicSettings/DefaultsReadUIWriteSettingHandler.swift
@@ -32,7 +32,7 @@ private let logger = OSLog(subsystem: "MorphicSettings", category: "DefaultsRead
 /// The asymmetry between read and write is because macOS won't let us write the user defaults directly.
 /// Additionally, several system settings checkboxes actually change more than one default and call private
 /// functions that we don't have access to, so using the UI is the best option.
-public class DefaultsReadUIWriteSettingHandler: SettingHandler{
+public class DefaultsReadUIWriteSettingHandler: SettingHandler {
     
     public required init(setting: Setting) {
         super.init(setting: setting)
@@ -43,9 +43,9 @@ public class DefaultsReadUIWriteSettingHandler: SettingHandler{
     private var defaults: UserDefaults?
     
     /// The data model describing the properties for this kind of setting handler
-    public struct Description: SettingHandlerDescription{
+    public struct Description: SettingHandlerDescription {
         
-        public var type: Setting.HandlerType{
+        public var type: Setting.HandlerType {
             return .defaultsReadUIWrite
         }
         
@@ -62,11 +62,11 @@ public class DefaultsReadUIWriteSettingHandler: SettingHandler{
         
         public let transform: Transform?
         
-        public enum Transform: String, Decodable{
+        public enum Transform: String, Decodable {
             case negateBoolean
         }
         
-        public enum CodingKeys: String, CodingKey{
+        public enum CodingKeys: String, CodingKey {
             case defaultsDomain = "defaults_domain"
             case defaultsKey = "defaults_key"
             case solution
@@ -75,7 +75,7 @@ public class DefaultsReadUIWriteSettingHandler: SettingHandler{
 //            case ui
         }
         
-        public init(from decoder: Decoder) throws{
+        public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             defaultsDomain = try container.decode(String.self, forKey: .defaultsDomain)
             defaultsKey = try container.decode(String.self, forKey: .defaultsKey)
@@ -86,38 +86,38 @@ public class DefaultsReadUIWriteSettingHandler: SettingHandler{
         }
     }
     
-//    public struct UIDescription: Decodable{
+//    public struct UIDescription: Decodable {
 //
 //        public let steps: [Step]
 //
-//        public enum CodingKeys: String, CodingKey{
+//        public enum CodingKeys: String, CodingKey {
 //            case steps
 //        }
 //
-//        public init(from decoder: Decoder) throws{
+//        public init(from decoder: Decoder) throws {
 //            let container = try decoder.container(keyedBy: CodingKeys.self)
 //            steps = try container.decode([Step].self, forKey: .steps)
 //        }
 //
 //    }
 //
-//    public struct Step: Decodable{
+//    public struct Step: Decodable {
 //        public var action: String
 //        public var identifier: String
 //
-//        public enum CodingKeys: String, CodingKey{
+//        public enum CodingKeys: String, CodingKey {
 //            case action
 //            case identifier
 //        }
 //
-//        public init(from decoder: Decoder) throws{
+//        public init(from decoder: Decoder) throws {
 //            let container = try decoder.container(keyedBy: CodingKeys.self)
 //            action = try container.decode(String.self, forKey: .action)
 //            identifier = try container.decode(String.self, forKey: .identifier)
 //        }
 //
-//        public func action(for value: Interoperable?) -> UIElement.Action?{
-//            switch action{
+//        public func action(for value: Interoperable?) -> UIElement.Action? {
+//            switch action {
 //            case "launch":
 //                return .launch(bundleIdentifier: identifier)
 //            case "press":
@@ -125,7 +125,7 @@ public class DefaultsReadUIWriteSettingHandler: SettingHandler{
 //            case "show":
 //                return .show(identifier: identifier)
 //            case "check":
-//                guard let checked = value as? Bool else{
+//                guard let checked = value as? Bool else {
 //                    return nil
 //                }
 //                return .check(checkboxTitle: identifier, checked: checked)
@@ -136,17 +136,17 @@ public class DefaultsReadUIWriteSettingHandler: SettingHandler{
 //    }
     
     /// The properly typed description for this handler
-    private var description: Description{
+    private var description: Description {
         return setting.handlerDescription as! Description
     }
     
     private static var automationTypesByKey = [Preferences.Key: UIAutomation.Type]()
     
-    public static func register(automation: UIAutomation.Type, for key: Preferences.Key){
+    public static func register(automation: UIAutomation.Type, for key: Preferences.Key) {
         automationTypesByKey[key] = automation
     }
     
-    public static func automation(for key: Preferences.Key) -> UIAutomation?{
+    public static func automation(for key: Preferences.Key) -> UIAutomation? {
         guard let type = automationTypesByKey[key] else{
             return nil
         }
@@ -172,17 +172,17 @@ public class DefaultsReadUIWriteSettingHandler: SettingHandler{
 //                completion(false)
 //                return
 //            }
-//            element.perform(action: action){
+//            element.perform(action: action) {
 //                success, nextTarget in
-//                guard success else{
+//                guard success else {
 //                    os_log(.error, log: logger, "Failed to perform action")
 //                    completion(false)
 //                    return
 //                }
-//                if let target = nextTarget{
+//                if let target = nextTarget {
 //                    element = target
 //                }
-//                if steps.count > 0{
+//                if steps.count > 0 {
 //                    runNextStep()
 //                }else{
 //                    completion(true)
@@ -193,13 +193,13 @@ public class DefaultsReadUIWriteSettingHandler: SettingHandler{
     }
     
     public override func read(completion: @escaping (_ result: SettingHandler.Result) -> Void) {
-        switch setting.type{
+        switch setting.type {
         case .boolean:
             guard var boolValue = defaults?.bool(forKey: description.defaultsKey) else{
                 completion(.failed)
                 return
             }
-            if let transform = description.transform{
+            if let transform = description.transform {
                 switch transform {
                 case .negateBoolean:
                     boolValue = !boolValue
@@ -207,7 +207,7 @@ public class DefaultsReadUIWriteSettingHandler: SettingHandler{
             }
             completion(.succeeded(value: boolValue))
         case .double:
-            guard let doubleValue = defaults?.double(forKey: description.defaultsKey) else{
+            guard let doubleValue = defaults?.double(forKey: description.defaultsKey) else {
                 completion(.failed)
                 return
             }
@@ -219,7 +219,7 @@ public class DefaultsReadUIWriteSettingHandler: SettingHandler{
             }
             completion(.succeeded(value: intValue))
         case .string:
-            guard let stringValue = defaults?.string(forKey: description.defaultsKey) else{
+            guard let stringValue = defaults?.string(forKey: description.defaultsKey) else {
                 completion(.failed)
                 return
             }

--- a/MorphicSettings/MorphicSettings/Display.swift
+++ b/MorphicSettings/MorphicSettings/Display.swift
@@ -24,9 +24,9 @@
 import Foundation
 import MorphicCore
 
-public class Display{
+public class Display {
     
-    init(id: UInt32){
+    init(id: UInt32) {
         self.id = id
         possibleModes = findPossibleModes()
         normalMode = possibleModes.first(where: { $0.isDefault })
@@ -41,36 +41,36 @@ public class Display{
         return nil
     }()
     
-    public func zoom(to percentage: Double) -> Bool{
+    public func zoom(to percentage: Double) -> Bool {
         guard let mode = self.mode(for: percentage) else{
             return false
         }
-        do{
+        do {
             try MorphicDisplay.setCurrentDisplayMode(for: id, to: mode)
             return true
-        }catch{
+        } catch {
             return false
         }
     }
     
-    public func percentage(zoomingIn steps: Int) -> Double{
-        guard let currentMode = currentMode, let normalMode = normalMode else{
+    public func percentage(zoomingIn steps: Int) -> Double {
+        guard let currentMode = currentMode, let normalMode = normalMode else {
             return 1
         }
         let target = possibleModes.reversed().first(where: { $0.widthInVirtualPixels < currentMode.widthInVirtualPixels }) ?? currentMode
         return Double(normalMode.widthInVirtualPixels) / Double(target.widthInVirtualPixels)
     }
     
-    public func percentage(zoomingOut steps: Int) -> Double{
-        guard let currentMode = currentMode, let normalMode = normalMode else{
+    public func percentage(zoomingOut steps: Int) -> Double {
+        guard let currentMode = currentMode, let normalMode = normalMode else {
             return 1
         }
         let target = possibleModes.first(where: { $0.widthInVirtualPixels > currentMode.widthInVirtualPixels }) ?? currentMode
         return Double(normalMode.widthInVirtualPixels) / Double(target.widthInVirtualPixels)
     }
     
-    public var currentPercentage: Double{
-        guard let currentMode = currentMode, let normalMode = normalMode else{
+    public var currentPercentage: Double {
+        guard let currentMode = currentMode, let normalMode = normalMode else {
             return 1
         }
         return Double(normalMode.widthInVirtualPixels) / Double(currentMode.widthInVirtualPixels)
@@ -80,8 +80,8 @@ public class Display{
         possibleModes.count
     }
     
-    public var currentStep: Int{
-        guard let current = currentMode else{
+    public var currentStep: Int {
+        guard let current = currentMode else {
             return -1
         }
         return possibleModes.firstIndex(of: current) ?? -1
@@ -91,28 +91,28 @@ public class Display{
     
     private var normalMode: MorphicDisplay.DisplayMode?
     
-    private var currentMode: MorphicDisplay.DisplayMode?{
+    private var currentMode: MorphicDisplay.DisplayMode? {
         return MorphicDisplay.getCurrentDisplayMode(for: id)
     }
     
-    private func findPossibleModes() -> [MorphicDisplay.DisplayMode]{
-        guard let modes = MorphicDisplay.getAllDisplayModes(for: id) else{
+    private func findPossibleModes() -> [MorphicDisplay.DisplayMode] {
+        guard let modes = MorphicDisplay.getAllDisplayModes(for: id) else {
             return []
         }
-        guard let currentMode = currentMode else{
+        guard let currentMode = currentMode else {
             return []
         }
         var possibleModes = modes.filter({ $0.isUsableForDesktopGui && $0.aspectRatio == currentMode.aspectRatio && $0.integerRefresh == currentMode.integerRefresh && $0.scale == currentMode.scale }).sorted(by: <)
-        for i in (1..<possibleModes.count).reversed(){
-            if possibleModes[i] == possibleModes[i - 1]{
+        for i in (1..<possibleModes.count).reversed() {
+            if possibleModes[i] == possibleModes[i - 1] {
                 possibleModes.remove(at: i)
             }
         }
         return possibleModes
     }
     
-    private func mode(for percentage: Double) -> MorphicDisplay.DisplayMode?{
-        guard let normalMode = normalMode else{
+    private func mode(for percentage: Double) -> MorphicDisplay.DisplayMode? {
+        guard let normalMode = normalMode else {
             return nil
         }
         let targetWidth = Int(round(Double(normalMode.widthInVirtualPixels) / percentage))
@@ -122,7 +122,7 @@ public class Display{
     
 }
 
-public class DisplayZoomHandler: ClientSettingHandler{
+public class DisplayZoomHandler: ClientSettingHandler {
     
     public override func read(completion: @escaping (SettingHandler.Result) -> Void) {
         guard let percentage = Display.main?.currentPercentage else {
@@ -147,9 +147,9 @@ public class DisplayZoomHandler: ClientSettingHandler{
     
 }
 
-private extension MorphicDisplay.DisplayMode{
+private extension MorphicDisplay.DisplayMode {
     
-    var stringRepresentation: String{
+    var stringRepresentation: String {
         var str = "\(widthInVirtualPixels)x\(heightInVirtualPixels)"
         if widthInPixels != widthInVirtualPixels || heightInPixels != heightInPixels{
             str += " (\(widthInPixels)x\(heightInPixels))"
@@ -160,7 +160,7 @@ private extension MorphicDisplay.DisplayMode{
         return str
     }
     
-    static func <(_ a: MorphicDisplay.DisplayMode, _ b: MorphicDisplay.DisplayMode) -> Bool{
+    static func <(_ a: MorphicDisplay.DisplayMode, _ b: MorphicDisplay.DisplayMode) -> Bool {
         var diff = a.widthInVirtualPixels - b.widthInVirtualPixels
         if diff == 0{
             diff = a.widthInPixels - b.widthInPixels
@@ -174,8 +174,8 @@ private extension MorphicDisplay.DisplayMode{
         return diff < 0
     }
     
-    var integerRefresh: Int?{
-        guard let refresh = refreshRateInHertz else{
+    var integerRefresh: Int? {
+        guard let refresh = refreshRateInHertz else {
             return nil
         }
         return Int(refresh)
@@ -186,25 +186,25 @@ private extension MorphicDisplay.DisplayMode{
         public var width: Int
         public var height: Int
         
-        init(width: Int, height: Int){
+        init(width: Int, height: Int) {
             self.width = width
             self.height = height
         }
         
-        public var value: Double{
+        public var value: Double {
             return Double(width) / Double(height)
         }
         
-        static func ==(_ a: AspectRatio, _ b: AspectRatio) -> Bool{
+        static func ==(_ a: AspectRatio, _ b: AspectRatio) -> Bool {
             return abs(a.value - b.value) < 0.1
         }
     }
     
-    var aspectRatio: AspectRatio{
+    var aspectRatio: AspectRatio {
         return AspectRatio(width: widthInVirtualPixels, height: heightInVirtualPixels)
     }
     
-    var scale: Int{
+    var scale: Int {
         return widthInVirtualPixels / widthInPixels
     }
     

--- a/MorphicSettings/MorphicSettings/Setting.swift
+++ b/MorphicSettings/MorphicSettings/Setting.swift
@@ -25,7 +25,7 @@ import Foundation
 import MorphicCore
 
 /// A data model describing an individual setting within a `Solution`
-public struct Setting: Decodable{
+public struct Setting: Decodable {
     
     /// The setting's locally-unique name within its owning `Solution`
     public let name: String
@@ -34,7 +34,7 @@ public struct Setting: Decodable{
     public let type: ValueType
     
     /// The possible types for values
-    public enum ValueType: String, Decodable{
+    public enum ValueType: String, Decodable {
         
         /// The value is a `String`
         case string
@@ -59,7 +59,7 @@ public struct Setting: Decodable{
     public let finalizerDescription: SettingFinalizerDescription?
     
     /// JSON decoding property map
-    private enum CodingKeys: String, CodingKey{
+    private enum CodingKeys: String, CodingKey {
         case name
         case type
         case defaultValue = "default"
@@ -71,12 +71,12 @@ public struct Setting: Decodable{
     ///
     /// Handler descriptions are based on the `type` value within the `handler` container, so
     /// we need to peek inside in order to create the correct handler description
-    private enum HandlerCodingKeys: String, CodingKey{
+    private enum HandlerCodingKeys: String, CodingKey {
         case type
     }
     
     /// The possible handler descriptions types
-    public enum HandlerType: String, Decodable{
+    public enum HandlerType: String, Decodable {
         
         /// Client handlers are custom code provided by the client application
         case client = "org.raisingthefloor.morphic.client"
@@ -92,72 +92,72 @@ public struct Setting: Decodable{
     ///
     /// Handler descriptions are based on the `type` value within the `finalizer` container, so
     /// we need to peek inside in order to create the correct handler description
-    private enum FinalizerCodingKeys: String, CodingKey{
+    private enum FinalizerCodingKeys: String, CodingKey {
         case type
     }
     
     /// The possible finalizer description types
-    public enum FinalizerType: String, Decodable{
+    public enum FinalizerType: String, Decodable {
         // TODO: remove after the first real case is added
         case notImplemented
     }
     
-    public init(from decoder: Decoder) throws{
+    public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         name = try container.decode(String.self, forKey: .name)
         type = try container.decode(ValueType.self, forKey: .type)
         defaultValue = try container.decodeInteroperable(for: .defaultValue)
         let handlerContainer = try container.nestedContainer(keyedBy: HandlerCodingKeys.self, forKey: .handler)
         let handlerType = try handlerContainer.decode(HandlerType.self, forKey: .type)
-        switch handlerType{
+        switch handlerType {
         case .client:
             handlerDescription = try container.decode(ClientSettingHandler.Description.self, forKey: .handler)
         case .defaultsReadUIWrite:
             handlerDescription = try container.decode(DefaultsReadUIWriteSettingHandler.Description.self, forKey: .handler)
         }
-        if container.contains(.finalizer){
+        if container.contains(.finalizer) {
             let finalizerContainer = try container.nestedContainer(keyedBy: FinalizerCodingKeys.self, forKey: .finalizer)
             let finalizerType = try finalizerContainer.decode(FinalizerType.self, forKey: .type)
-            switch finalizerType{
+            switch finalizerType {
             case .notImplemented:
                 finalizerDescription = nil
             }
-        }else{
+        } else {
             finalizerDescription = nil
         }
     }
     
-    public func isDefault(_ value: Interoperable?) -> Bool{
+    public func isDefault(_ value: Interoperable?) -> Bool {
         switch type {
         case .boolean:
-            guard let defaultValue = defaultValue as? Bool else{
+            guard let defaultValue = defaultValue as? Bool else {
                 return false
             }
-            guard let value = value as? Bool else{
+            guard let value = value as? Bool else {
                 return false
             }
             return value == defaultValue
         case .integer:
-            guard let defaultValue = defaultValue as? Int else{
+            guard let defaultValue = defaultValue as? Int else {
                 return false
             }
-            guard let value = value as? Int else{
+            guard let value = value as? Int else {
                 return false
             }
             return value == defaultValue
         case .string:
-            guard let defaultValue = defaultValue as? String else{
+            guard let defaultValue = defaultValue as? String else {
                 return false
             }
-            guard let value = value as? String else{
+            guard let value = value as? String else {
                 return false
             }
             return value == defaultValue
         case .double:
-            guard let defaultValue = defaultValue as? Double else{
+            guard let defaultValue = defaultValue as? Double else {
                 return false
             }
-            guard let value = value as? Double else{
+            guard let value = value as? Double else {
                 return false
             }
             return value == defaultValue

--- a/MorphicSettings/MorphicSettings/SettingFinalizer.swift
+++ b/MorphicSettings/MorphicSettings/SettingFinalizer.swift
@@ -29,22 +29,22 @@ import MorphicCore
 /// For example, a finalizer might be used to restart a process or perform a system call that refreshes some
 /// UI components.  Rather than do this operation after each setting changes, finalizers provide a way to
 /// perform the operation only once after all the settings have been updated.
-public class SettingFinalizer{
+public class SettingFinalizer {
     
     /// Create a finalizer from the given description
-    public required init(description: SettingFinalizerDescription){
+    public required init(description: SettingFinalizerDescription) {
         self.description = description
     }
     
     public let description: SettingFinalizerDescription
     
     /// Run the finalizer's operation
-    public func run(completion: @escaping (_ success: Bool) -> Void){
+    public func run(completion: @escaping (_ success: Bool) -> Void) {
         completion(false)
     }
     
-    public static func create(from description: SettingFinalizerDescription) -> SettingFinalizer?{
-        switch description.type{
+    public static func create(from description: SettingFinalizerDescription) -> SettingFinalizer? {
+        switch description.type {
         case .notImplemented:
             return nil
         }
@@ -53,7 +53,7 @@ public class SettingFinalizer{
 }
 
 /// A data model describing the finalizer's behavior
-public protocol SettingFinalizerDescription{
+public protocol SettingFinalizerDescription {
     
     var type: Setting.FinalizerType { get }
     

--- a/MorphicSettings/MorphicSettings/SettingHandler.swift
+++ b/MorphicSettings/MorphicSettings/SettingHandler.swift
@@ -28,13 +28,13 @@ import MorphicCore
 ///
 /// Sublclasses should define a `Definition` data model that conforms to
 /// `SettingHandlerDescription` and describes the handler's properties
-public class SettingHandler{
+public class SettingHandler {
     
     /// Create a setting handler for the given setting
     ///
     /// - parameters:
     ///   - setting: The description of the setting to read/write
-    public required init(setting: Setting){
+    public required init(setting: Setting) {
         self.setting = setting
     }
     
@@ -44,12 +44,12 @@ public class SettingHandler{
     ///   - value: The value to save for `setting`
     ///   - completion: Called when the write completes
     ///   - success: Whether the write succeeded
-    public func apply(_ value: Interoperable?, completion: @escaping (_ success: Bool) -> Void){
+    public func apply(_ value: Interoperable?, completion: @escaping (_ success: Bool) -> Void) {
         completion(false)
     }
     
     /// Possbile results for reading a setting's value
-    public enum Result{
+    public enum Result {
         /// The read succeeded, with the value
         case succeeded(value: Interoperable)
         /// The read failed
@@ -61,7 +61,7 @@ public class SettingHandler{
     /// - parameters:
     ///   - completion: Called when the read completes
     ///   - result: The result of the read
-    public func read(completion: @escaping (_ result: Result) -> Void){
+    public func read(completion: @escaping (_ result: Result) -> Void) {
         completion(.failed)
     }
     
@@ -71,15 +71,15 @@ public class SettingHandler{
 }
 
 /// A protocol that should be adopted by any data  model describing a setting handler
-public protocol SettingHandlerDescription: Decodable{
+public protocol SettingHandlerDescription: Decodable {
     
     var type: Setting.HandlerType { get }
     
 }
 
-public extension Setting{
+public extension Setting {
     
-    func createHandler() -> SettingHandler?{
+    func createHandler() -> SettingHandler? {
         switch handlerDescription.type{
         case .client:
             return ClientSettingHandler.create(for: self)

--- a/MorphicSettings/MorphicSettings/SettingsManager.swift
+++ b/MorphicSettings/MorphicSettings/SettingsManager.swift
@@ -28,12 +28,12 @@ import OSLog
 private let logger = OSLog(subsystem: "MorphicSettings", category: "SettingsManager")
 
 /// Manages system settings based on morphic preferences
-public class SettingsManager{
+public class SettingsManager {
     
     /// The singleton object representing this system's settings
     public static var shared: SettingsManager = SettingsManager()
     
-    private init(){
+    private init() {
         ClientSettingHandler.register(type: DisplayZoomHandler.self, for: .macosDisplayZoom)
         DefaultsReadUIWriteSettingHandler.register(automation: ContrastUIAutomation.self, for: .macosDisplayContrastEnabled)
         DefaultsReadUIWriteSettingHandler.register(automation: InvertColorsUIAutomation.self, for: .macosDisplayInvertColors)
@@ -64,30 +64,30 @@ public class SettingsManager{
     private var solutionsById = [String: Solution]()
     
     /// Add solutions to the settings manager by parsing JSON
-    public func populateSolutions(fromResource resource: String, in bundle: Bundle = Bundle.main){
-        guard let url = bundle.url(forResource: resource, withExtension: "json") else{
+    public func populateSolutions(fromResource resource: String, in bundle: Bundle = Bundle.main) {
+        guard let url = bundle.url(forResource: resource, withExtension: "json") else {
             os_log(.error, log: logger, "Failed to find solutions json resource")
             return
         }
         populateSolutions(from: url)
     }
     
-    public func populateSolutions(from url: URL){
-        guard let data = FileManager.default.contents(atPath: url.path) else{
+    public func populateSolutions(from url: URL) {
+        guard let data = FileManager.default.contents(atPath: url.path) else {
             os_log(.error, log: logger, "Failed to read contents of solutions json resource")
             return
         }
         populateSolutions(from: data)
     }
     
-    public func populateSolutions(from data: Data){
+    public func populateSolutions(from data: Data) {
         let decoder = JSONDecoder()
-        guard let solutions = try? decoder.decode([Solution].self, from: data) else{
+        guard let solutions = try? decoder.decode([Solution].self, from: data) else {
             os_log(.error, log: logger, "Failed to decode JSON from solutions file")
             return
         }
         self.solutions = solutions
-        for solution in solutions{
+        for solution in solutions {
             solutionsById[solution.identifier] = solution
         }
     }
@@ -95,7 +95,7 @@ public class SettingsManager{
     /// Get the setting for the given key
     ///
     /// - parameter key: The key to use when looking up the setting
-    public func setting(for key: Preferences.Key) -> Setting?{
+    public func setting(for key: Preferences.Key) -> Setting? {
         guard let solution = solutionsById[key.solution] else{
             return nil
         }
@@ -103,7 +103,7 @@ public class SettingsManager{
     }
     
     /// Apply a value for Morphic preference in the given solution
-    public func apply(_ value: Interoperable?, for key: Preferences.Key, completion: @escaping (_ success: Bool) -> Void){
+    public func apply(_ value: Interoperable?, for key: Preferences.Key, completion: @escaping (_ success: Bool) -> Void) {
         apply(values: [(key, value)]){
             results in
             completion(results[key] ?? false)
@@ -111,7 +111,7 @@ public class SettingsManager{
     }
     
     /// Apply several values at once
-    public func apply(values: [(Preferences.Key, Interoperable?)], completion: @escaping (_ results: [Preferences.Key: Bool]) -> Void){
+    public func apply(values: [(Preferences.Key, Interoperable?)], completion: @escaping (_ results: [Preferences.Key: Bool]) -> Void) {
         let session = ApplySession(settingsManager: self, keyValueTuples: values)
         session.run{
             completion(session.results)
@@ -119,15 +119,15 @@ public class SettingsManager{
     }
     
     /// Capture a value for the given preference
-    public func capture(valueFor key: Preferences.Key, completion: @escaping (_ result: Interoperable?) -> Void){
-        capture(valuesFor: [key]){
+    public func capture(valueFor key: Preferences.Key, completion: @escaping (_ result: Interoperable?) -> Void) {
+        capture(valuesFor: [key]) {
             results in
             completion(results[key] ?? nil)
         }
     }
     
     /// Capture many values at once
-    public func capture(valuesFor keys: [Preferences.Key], completion: @escaping(_ results: [Preferences.Key: Interoperable?]) -> Void){
+    public func capture(valuesFor keys: [Preferences.Key], completion: @escaping(_ results: [Preferences.Key: Interoperable?]) -> Void) {
         let prefs = Preferences(identifier: "")
         let session = CaptureSession(settingsManager: self, preferences: prefs)
         session.captureDefaultValues = true
@@ -140,7 +140,7 @@ public class SettingsManager{
     
 }
 
-public extension Preferences.Key{
+public extension Preferences.Key {
     // Display
     static var macosDisplayZoom = Preferences.Key(solution: "com.apple.macos.display", preference: "zoom")
     static var macosDisplayContrastEnabled = Preferences.Key(solution: "com.apple.macos.display", preference: "contrast.enabled")

--- a/MorphicSettings/MorphicSettings/Solution.swift
+++ b/MorphicSettings/MorphicSettings/Solution.swift
@@ -33,7 +33,7 @@ import MorphicCore
 ///
 /// Within a solution is a list of related settings that control fine-grained details
 /// of how the feature works.
-public struct Solution: Decodable{
+public struct Solution: Decodable {
     
     /// The globally unique identifier for the solution, typically in reverse-domain style
     public let identifier: String
@@ -44,7 +44,7 @@ public struct Solution: Decodable{
     /// Get the setting for the given name
     ///
     /// - parameter name: The locally-unique name for a setting
-    public func setting(for name: String) -> Setting?{
+    public func setting(for name: String) -> Setting? {
         return settingsByName[name]
     }
     
@@ -52,13 +52,13 @@ public struct Solution: Decodable{
     private let settingsByName: [String: Setting]
     
     /// JSON property name map
-    private enum CodingKeys: String, CodingKey{
+    private enum CodingKeys: String, CodingKey {
         case identifier = "id"
         case settings
     }
     
     /// Create a Solution from a decoder (JSON)
-    public init(from decoder: Decoder) throws{
+    public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         identifier = try container.decode(String.self, forKey: .identifier)
         settings = try container.decode([Setting].self, forKey: .settings)
@@ -73,7 +73,7 @@ public struct Solution: Decodable{
     /// - parameters:
     ///   - identifier: The solution's unique identifier
     ///   - settings: The settings in this solution
-    public init(identifier: String, settings: [Setting]){
+    public init(identifier: String, settings: [Setting]) {
         self.identifier = identifier
         self.settings = settings
         settingsByName = settings.dictionaryByName()
@@ -81,9 +81,9 @@ public struct Solution: Decodable{
     
 }
 
-fileprivate extension Array where Element == Setting{
+fileprivate extension Array where Element == Setting {
     
-    func dictionaryByName() -> [String: Setting]{
+    func dictionaryByName() -> [String: Setting] {
         var dictionary = [String: Setting]()
         for setting in self{
             dictionary[setting.name] = setting

--- a/MorphicSettings/MorphicSettings/SystemPreferences.swift
+++ b/MorphicSettings/MorphicSettings/SystemPreferences.swift
@@ -23,20 +23,20 @@
 
 import Foundation
 
-public class SystemPreferences{
+public class SystemPreferences {
     
-    private init(){
+    private init() {
     }
     
     public static let shared = SystemPreferences()
     
     public let accessibility = AccessibilitySystemPreferencesPane()
     
-    public enum PaneIdentifier: String, Codable{
+    public enum PaneIdentifier: String, Codable {
         case accessibility
     }
     
-    public func pane(for identifier: PaneIdentifier) -> SystemPreferencesPane{
+    public func pane(for identifier: PaneIdentifier) -> SystemPreferencesPane {
         switch identifier {
         case .accessibility:
             return accessibility
@@ -45,12 +45,10 @@ public class SystemPreferences{
     
 }
 
-public class SystemPreferencesPane{
+public class SystemPreferencesPane {
     
 }
 
-public class AccessibilitySystemPreferencesPane: SystemPreferencesPane{
-    
-    
+public class AccessibilitySystemPreferencesPane: SystemPreferencesPane {
     
 }


### PR DESCRIPTION
This PR looks like an enormous # of changes, but it's almost entirely a bunch of spaces added before/after curly braces (per the conversation I had with Owen last week).

Example 1:
"}else{" 
-> 
"} else {"

Example 2:
Removal of "end of line" semicolons (holdovers from C no longer used in Swift, and often not supported in Swift)

I also quite a bit of linting on the new MorphicManualTester (the first two checkins), including removal of semicolons and vestigial parentheses.  And I upgraded/swiftified the nil checks with "if let" and "guard let" blocks, corrected MorphicManualTester's camel casing, etc.

This PR should not break any code and is designed to be purely cosmetic in nature.  I recommend we pull this in now so that new PRs build on top of the linted base.