### PR TITLE
add about box

### DIFF
--- a/Morphic/Morphic.xcodeproj/project.pbxproj
+++ b/Morphic/Morphic.xcodeproj/project.pbxproj
@@ -70,6 +70,9 @@
 		31E1E185244683DC009C4092 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E1E184244683DC009C4092 /* Theme.swift */; };
 		31E1E187244792D9009C4092 /* DefaultPreferences.json in Resources */ = {isa = PBXBuildFile; fileRef = 31E1E186244792D9009C4092 /* DefaultPreferences.json */; };
 		31E1E188244794EF009C4092 /* MorphicBarViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 31E1E18A244794EF009C4092 /* MorphicBarViewController.xib */; };
+		9D82576E24D31C1E00F6E932 /* AboutBoxWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D82576C24D31C1E00F6E932 /* AboutBoxWindowController.swift */; };
+		9D82576F24D31C1E00F6E932 /* AboutBoxWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9D82576D24D31C1E00F6E932 /* AboutBoxWindowController.xib */; };
+		9D82577124D353C800F6E932 /* HyperlinkTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D82577024D353C800F6E932 /* HyperlinkTextField.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -217,6 +220,9 @@
 		31E1E184244683DC009C4092 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		31E1E186244792D9009C4092 /* DefaultPreferences.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = DefaultPreferences.json; sourceTree = "<group>"; };
 		31E1E189244794EF009C4092 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MorphicBarViewController.xib; sourceTree = "<group>"; };
+		9D82576C24D31C1E00F6E932 /* AboutBoxWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutBoxWindowController.swift; sourceTree = "<group>"; };
+		9D82576D24D31C1E00F6E932 /* AboutBoxWindowController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AboutBoxWindowController.xib; sourceTree = "<group>"; };
+		9D82577024D353C800F6E932 /* HyperlinkTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperlinkTextField.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -347,6 +353,7 @@
 				31751B972444F21700EEDF14 /* Session.swift */,
 				31E1E184244683DC009C4092 /* Theme.swift */,
 				31E1E186244792D9009C4092 /* DefaultPreferences.json */,
+				9D82576724D3160600F6E932 /* About Box */,
 				31751B3F2444E01B00EEDF14 /* MorphicBar */,
 				31CE56EC244A3C9800A52A7B /* Help Window */,
 				314EB6D924A6978200CF3D48 /* Solutions */,
@@ -445,6 +452,16 @@
 				31C12CC324B1441E00B617A8 /* PageControl.swift */,
 			);
 			path = "Help Window";
+			sourceTree = "<group>";
+		};
+		9D82576724D3160600F6E932 /* About Box */ = {
+			isa = PBXGroup;
+			children = (
+				9D82576C24D31C1E00F6E932 /* AboutBoxWindowController.swift */,
+				9D82576D24D31C1E00F6E932 /* AboutBoxWindowController.xib */,
+				9D82577024D353C800F6E932 /* HyperlinkTextField.swift */,
+			);
+			path = "About Box";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -626,6 +643,7 @@
 			files = (
 				31C12CC224B143A000B617A8 /* QuickHelpStepViewController.xib in Resources */,
 				31751B822444E11600EEDF14 /* Local.xcconfig in Resources */,
+				9D82576F24D31C1E00F6E932 /* AboutBoxWindowController.xib in Resources */,
 				31CE56F5244A407000A52A7B /* QuickHelpViewController.xib in Resources */,
 				31751B3C2444DFAA00EEDF14 /* Main.xib in Resources */,
 				31E1E188244794EF009C4092 /* MorphicBarViewController.xib in Resources */,
@@ -742,6 +760,8 @@
 				31751B0D2444DE8900EEDF14 /* AppDelegate.swift in Sources */,
 				31C12CBE24B138D000B617A8 /* ProgressIndicator.swift in Sources */,
 				31C12CC424B1441E00B617A8 /* PageControl.swift in Sources */,
+				9D82576E24D31C1E00F6E932 /* AboutBoxWindowController.swift in Sources */,
+				9D82577124D353C800F6E932 /* HyperlinkTextField.swift in Sources */,
 				31E1E17B24466D28009C4092 /* MorphicBarItem.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -983,6 +1003,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MARKETING_VERSION = 0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.raisingthefloor.Morphic-Debug";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1005,6 +1026,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MARKETING_VERSION = 0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = org.raisingthefloor.Morphic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Morphic Client for macOS";

--- a/Morphic/Morphic/About Box/AboutBoxWindowController.swift
+++ b/Morphic/Morphic/About Box/AboutBoxWindowController.swift
@@ -1,0 +1,89 @@
+// Copyright 2020 Raising the Floor - International
+//
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
+//
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
+//
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
+
+import Cocoa
+
+class AboutBoxWindowController: NSWindowController, NSWindowDelegate {
+
+    private static var singleWindowController: AboutBoxWindowController?
+    
+    @IBOutlet weak var versionTextField: NSTextField!
+    @IBOutlet weak var buildTextField: NSTextField!
+    
+    override var windowNibName: NSNib.Name? {
+        return NSNib.Name("AboutBoxWindowController")
+    }
+    
+    //
+
+    static var single: AboutBoxWindowController {
+        if let singleWindowController = self.singleWindowController {
+            return singleWindowController
+        } else {
+            let aboutBoxWindowController = AboutBoxWindowController()
+            aboutBoxWindowController.window?.delegate = aboutBoxWindowController
+            //
+            AboutBoxWindowController.singleWindowController = aboutBoxWindowController
+            return aboutBoxWindowController
+        }
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        AboutBoxWindowController.singleWindowController = nil
+    }
+
+    //
+    
+    override func windowDidLoad() {
+        super.windowDidLoad()
+
+        // populate the version and build # in our labels
+        if let shortVersionAsString = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+            versionTextField.stringValue = shortVersionAsString
+        } else {
+            assertionFailure("could not retrieve application version #")
+            versionTextField.stringValue = "[version is unknown]"
+        }
+        //
+        // NOTE: for future use: if we incremenet the build version, we can show the build information; for now, just show an empty box
+buildTextField.stringValue = ""
+//        if let buildAsString = Bundle.main.infoDictionary?["CustomBuildInfo" as String] {
+//            buildTextField.stringValue = "(build \(buildAsString))"
+//        } else {
+//            assertionFailure("could not retrieve application build #")
+//            buildTextField.stringValue = "[bundle version is unknown]"
+//        }
+    }
+    
+    func centerOnScreen() {
+        guard let screenFrame = NSScreen.main?.frame else {
+            return
+        }
+        guard let windowFrame = self.window?.frame else {
+            return
+        }
+        
+        let newOrigin = NSPoint(x: (screenFrame.width - windowFrame.width) / 2, y: (screenFrame.height - windowFrame.height) / 2)
+        self.window?.setFrameOrigin(newOrigin)
+    }
+}

--- a/Morphic/Morphic/About Box/AboutBoxWindowController.xib
+++ b/Morphic/Morphic/About Box/AboutBoxWindowController.xib
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="AboutBoxWindowController" customModule="Morphic" customModuleProvider="target">
+            <connections>
+                <outlet property="buildTextField" destination="onK-5c-5rq" id="tFX-mt-jlh"/>
+                <outlet property="versionTextField" destination="Mly-xV-m1p" id="zO1-ty-Lng"/>
+                <outlet property="window" destination="F0z-JX-Cv5" id="gIp-Ho-8D9"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <window title="About Morphic" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" titlebarAppearsTransparent="YES" id="F0z-JX-Cv5">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
+            <rect key="contentRect" x="196" y="240" width="403" height="255"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1792" height="1097"/>
+            <view key="contentView" id="se5-gp-TjO">
+                <rect key="frame" x="0.0" y="0.0" width="403" height="255"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Auq-sw-XnR">
+                        <rect key="frame" x="178" y="159" width="48" height="48"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="48" id="5DY-1f-4K2"/>
+                            <constraint firstAttribute="width" constant="48" id="UtP-N0-LyG"/>
+                        </constraints>
+                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="Icon" id="gFD-l3-ahg"/>
+                    </imageView>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xiq-0B-kHt">
+                        <rect key="frame" x="137" y="112" width="129" height="16"/>
+                        <textFieldCell key="cell" lineBreakMode="clipping" title="Morphic for macOS" id="P3l-Rg-JEz">
+                            <font key="font" metaFont="systemBold"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Mly-xV-m1p">
+                        <rect key="frame" x="177" y="88" width="50" height="16"/>
+                        <textFieldCell key="cell" lineBreakMode="clipping" title="Version" id="rtb-dd-Jkw">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="onK-5c-5rq">
+                        <rect key="frame" x="180" y="64" width="44" height="16"/>
+                        <textFieldCell key="cell" lineBreakMode="clipping" title="(Build)" id="dcf-3V-XXl">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sdd-Te-nD9" customClass="HyperlinkTextField" customModule="Morphic" customModuleProvider="target">
+                        <rect key="frame" x="170" y="42" width="63" height="14"/>
+                        <textFieldCell key="cell" lineBreakMode="clipping" title="Contact Us" id="bKV-Nb-ezu">
+                            <font key="font" metaFont="label" size="11"/>
+                            <color key="textColor" name="linkColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="urlAsString" value="mailto:support@morphic.org"/>
+                        </userDefinedRuntimeAttributes>
+                    </textField>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="Auq-sw-XnR" firstAttribute="top" secondItem="se5-gp-TjO" secondAttribute="top" constant="48" id="0B1-Cy-Qnr"/>
+                    <constraint firstItem="xiq-0B-kHt" firstAttribute="top" secondItem="Auq-sw-XnR" secondAttribute="bottom" constant="31" id="2sD-MW-6St"/>
+                    <constraint firstItem="onK-5c-5rq" firstAttribute="top" secondItem="Mly-xV-m1p" secondAttribute="bottom" constant="8" id="EP9-qv-Zdi"/>
+                    <constraint firstItem="sdd-Te-nD9" firstAttribute="top" secondItem="onK-5c-5rq" secondAttribute="bottom" constant="8" id="Iu0-44-ae0"/>
+                    <constraint firstItem="Auq-sw-XnR" firstAttribute="centerX" secondItem="se5-gp-TjO" secondAttribute="centerX" id="OxA-Yi-Dig"/>
+                    <constraint firstItem="Mly-xV-m1p" firstAttribute="top" secondItem="xiq-0B-kHt" secondAttribute="bottom" constant="8" id="eON-GN-bJG"/>
+                    <constraint firstItem="sdd-Te-nD9" firstAttribute="centerX" secondItem="se5-gp-TjO" secondAttribute="centerX" id="fDB-ff-UAG"/>
+                    <constraint firstItem="Mly-xV-m1p" firstAttribute="centerX" secondItem="se5-gp-TjO" secondAttribute="centerX" id="pbl-0j-0dg"/>
+                    <constraint firstItem="onK-5c-5rq" firstAttribute="centerX" secondItem="se5-gp-TjO" secondAttribute="centerX" id="qEG-A8-ves"/>
+                    <constraint firstItem="xiq-0B-kHt" firstAttribute="centerX" secondItem="se5-gp-TjO" secondAttribute="centerX" id="qfB-CD-GKg"/>
+                </constraints>
+            </view>
+            <connections>
+                <outlet property="delegate" destination="-2" id="0bl-1N-AYu"/>
+            </connections>
+            <point key="canvasLocation" x="100.5" y="139.5"/>
+        </window>
+    </objects>
+    <resources>
+        <image name="Icon" width="512" height="512"/>
+    </resources>
+</document>

--- a/Morphic/Morphic/About Box/HyperlinkTextField.swift
+++ b/Morphic/Morphic/About Box/HyperlinkTextField.swift
@@ -1,0 +1,68 @@
+// Copyright 2020 Raising the Floor - International
+//
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
+//
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
+//
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
+
+import Cocoa
+
+class HyperlinkTextField: NSTextField {
+    @IBInspectable
+    var urlAsString: String? = nil
+    
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+    }
+    
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+
+        // clear out our current tracking areas
+        for trackingArea in trackingAreas {
+            removeTrackingArea(trackingArea)
+        }
+
+        // add a new tracking area equal to our bounds (and capturing our mouseEntered and mouseExited events)
+        let newTrackingArea = NSTrackingArea(rect: self.bounds, options: [.activeAlways, .mouseEnteredAndExited], owner: self, userInfo: nil)
+        addTrackingArea(newTrackingArea)
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        super.mouseEntered(with: event)
+        
+        NSCursor.pointingHand.set()
+    }
+    
+    override func mouseExited(with event: NSEvent) {
+        super.mouseExited(with: event)
+        
+        NSCursor.arrow.set()
+    }
+    
+    override func mouseUp(with event: NSEvent) {
+        super.mouseUp(with: event)
+        
+        if let urlAsString = self.urlAsString {
+            if let url = URL(string: urlAsString) {
+                NSWorkspace.shared.open(url)
+            }
+        }
+    }
+}

--- a/Morphic/Morphic/AppDelegate.swift
+++ b/Morphic/Morphic/AppDelegate.swift
@@ -120,6 +120,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
     }
     
+    @IBAction func showAboutBox(_ sender: NSMenuItem) {
+        let aboutBoxWindowController = AboutBoxWindowController.single
+        if aboutBoxWindowController.window?.isVisible == false {
+            aboutBoxWindowController.centerOnScreen()
+        }
+        
+        aboutBoxWindowController.showWindow(self)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
     // MARK: - Default Preferences
     
     func createEmptyDefaultPreferencesIfNotExist(completion: @escaping () -> Void) {

--- a/Morphic/Morphic/Base.lproj/Main.xib
+++ b/Morphic/Morphic/Base.lproj/Main.xib
@@ -53,6 +53,12 @@
                     </connections>
                 </menuItem>
                 <menuItem isSeparatorItem="YES" id="yYL-r6-1AR"/>
+                <menuItem title="About Morphic..." id="m2n-v5-G3Y">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="showAboutBox:" target="ZNk-5q-oDb" id="wZn-jB-dZm"/>
+                    </connections>
+                </menuItem>
                 <menuItem title="Quit Morphic" keyEquivalent="q" id="aYd-9o-084">
                     <connections>
                         <action selector="terminate:" target="-1" id="oZz-fZ-cJR"/>

--- a/Morphic/Morphic/Info.plist
+++ b/Morphic/Morphic/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Morphic/Morphic/MorphicBar/Base.lproj/MorphicBarViewController.xib
+++ b/Morphic/Morphic/MorphicBar/Base.lproj/MorphicBarViewController.xib
@@ -80,6 +80,12 @@
                     </connections>
                 </menuItem>
                 <menuItem isSeparatorItem="YES" id="vgL-Lb-axj"/>
+                <menuItem title="About Morphic..." id="GjN-rN-rcZ">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="showAboutBox:" target="-1" id="iCU-gX-DgC"/>
+                    </connections>
+                </menuItem>
                 <menuItem title="Quit Morphic" keyEquivalent="q" id="tHP-m8-Lto">
                     <connections>
                         <action selector="terminate:" target="-1" id="AxL-78-D9D"/>


### PR DESCRIPTION
JIRA issue: # MOR-40

I have added an "About" box to Morphic.  It is accessible from both the Morphic menu bar icon's menu...and also from the MorphicBar's advanced features pop-up menu.

Please note that the Windows version of Morphic does not show "About Morphic..." on the MorphicBar's pop-up menu.  We should make the two consistent (either adding it to Windows so that the MorphicBar and system tray menus are the same on Windows...or removing it on the MorphicBar's pop-up menu on macOS).

For now, the app is just showing the marketing version # ("0.9", etc.) as set in info.plist or the project settings.  As a follow-up task, we should integrate versioning with the build system so that the app shows the specific build information in the About dialog as well.