### PR TITLE
change MorphicBar button segment colors, add intersegment margin

### DIFF
--- a/Morphic/Morphic/MorphicBar/MorphicBarSegmentedButton.swift
+++ b/Morphic/Morphic/MorphicBar/MorphicBarSegmentedButton.swift
@@ -117,6 +117,8 @@ class MorphicBarSegmentedButton: NSControl {
     
     // MARK: - Layout
     
+    let horizontalMarginBetweenSegments = CGFloat(1.5)
+    
     override var isFlipped: Bool {
         return true
     }
@@ -137,6 +139,7 @@ class MorphicBarSegmentedButton: NSControl {
             let buttonSize = button.intrinsicContentSize
             size.width += buttonSize.width
         }
+        size.width += CGFloat(max(segmentButtons.count - 1, 0)) * horizontalMarginBetweenSegments
         return size
     }
     
@@ -146,7 +149,7 @@ class MorphicBarSegmentedButton: NSControl {
             let buttonSize = button.intrinsicContentSize
             frame.size.width = buttonSize.width
             button.frame = frame
-            frame.origin.x += frame.size.width
+            frame.origin.x += frame.size.width + horizontalMarginBetweenSegments
         }
     }
     
@@ -264,7 +267,9 @@ class MorphicBarSegmentedButton: NSControl {
         }
         button.setAccessibilityLabel(segment.accessibilityLabel)
         button.helpProvider = segment.helpProvider
-        (button.cell as? NSButtonCell)?.backgroundColor = segment.isPrimary ? primarySegmentColor : secondarySegmentColor
+        (button.cell as? NSButtonCell)?.backgroundColor = primarySegmentColor
+        // NOTE: to use two alternating (contrasting) colors, uncomment the following line and set horizontalMarginBetweenSegments to 0.
+//        (button.cell as? NSButtonCell)?.backgroundColor = segment.isPrimary ? primarySegmentColor : secondarySegmentColor
         button.font = font
         return button
     }


### PR DESCRIPTION
JIRA Issue #: MOR-77

The color of MorphicBar's SegmentedButtons' colors has been changed, to be consistent with Morphic on Windows.

I used a spacing of 1.5 units between buttons, as 1 unit felt too small to be easily visible and 2 units felt like the buttons were starting to lose group/segment cohesion.  If in testing we find that the spacing should be increased/decreased, we can do so by simply changing the new horizontalMarginBetweenSegments variable's value.