### PR TITLE
Remove "high contrast" button and replace it with "night mode"

### DIFF
--- a/Morphic/Morphic.xcodeproj/project.pbxproj
+++ b/Morphic/Morphic.xcodeproj/project.pbxproj
@@ -70,6 +70,9 @@
 		31E1E185244683DC009C4092 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E1E184244683DC009C4092 /* Theme.swift */; };
 		31E1E187244792D9009C4092 /* DefaultPreferences.json in Resources */ = {isa = PBXBuildFile; fileRef = 31E1E186244792D9009C4092 /* DefaultPreferences.json */; };
 		31E1E188244794EF009C4092 /* MorphicBarViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 31E1E18A244794EF009C4092 /* MorphicBarViewController.xib */; };
+		9D82576E24D31C1E00F6E932 /* AboutBoxWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D82576C24D31C1E00F6E932 /* AboutBoxWindowController.swift */; };
+		9D82576F24D31C1E00F6E932 /* AboutBoxWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9D82576D24D31C1E00F6E932 /* AboutBoxWindowController.xib */; };
+		9D82577124D353C800F6E932 /* HyperlinkTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D82577024D353C800F6E932 /* HyperlinkTextField.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -217,6 +220,9 @@
 		31E1E184244683DC009C4092 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		31E1E186244792D9009C4092 /* DefaultPreferences.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = DefaultPreferences.json; sourceTree = "<group>"; };
 		31E1E189244794EF009C4092 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MorphicBarViewController.xib; sourceTree = "<group>"; };
+		9D82576C24D31C1E00F6E932 /* AboutBoxWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutBoxWindowController.swift; sourceTree = "<group>"; };
+		9D82576D24D31C1E00F6E932 /* AboutBoxWindowController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AboutBoxWindowController.xib; sourceTree = "<group>"; };
+		9D82577024D353C800F6E932 /* HyperlinkTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperlinkTextField.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -347,6 +353,7 @@
 				31751B972444F21700EEDF14 /* Session.swift */,
 				31E1E184244683DC009C4092 /* Theme.swift */,
 				31E1E186244792D9009C4092 /* DefaultPreferences.json */,
+				9D82576724D3160600F6E932 /* About Box */,
 				31751B3F2444E01B00EEDF14 /* MorphicBar */,
 				31CE56EC244A3C9800A52A7B /* Help Window */,
 				314EB6D924A6978200CF3D48 /* Solutions */,
@@ -445,6 +452,16 @@
 				31C12CC324B1441E00B617A8 /* PageControl.swift */,
 			);
 			path = "Help Window";
+			sourceTree = "<group>";
+		};
+		9D82576724D3160600F6E932 /* About Box */ = {
+			isa = PBXGroup;
+			children = (
+				9D82576C24D31C1E00F6E932 /* AboutBoxWindowController.swift */,
+				9D82576D24D31C1E00F6E932 /* AboutBoxWindowController.xib */,
+				9D82577024D353C800F6E932 /* HyperlinkTextField.swift */,
+			);
+			path = "About Box";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -626,6 +643,7 @@
 			files = (
 				31C12CC224B143A000B617A8 /* QuickHelpStepViewController.xib in Resources */,
 				31751B822444E11600EEDF14 /* Local.xcconfig in Resources */,
+				9D82576F24D31C1E00F6E932 /* AboutBoxWindowController.xib in Resources */,
 				31CE56F5244A407000A52A7B /* QuickHelpViewController.xib in Resources */,
 				31751B3C2444DFAA00EEDF14 /* Main.xib in Resources */,
 				31E1E188244794EF009C4092 /* MorphicBarViewController.xib in Resources */,
@@ -742,6 +760,8 @@
 				31751B0D2444DE8900EEDF14 /* AppDelegate.swift in Sources */,
 				31C12CBE24B138D000B617A8 /* ProgressIndicator.swift in Sources */,
 				31C12CC424B1441E00B617A8 /* PageControl.swift in Sources */,
+				9D82576E24D31C1E00F6E932 /* AboutBoxWindowController.swift in Sources */,
+				9D82577124D353C800F6E932 /* HyperlinkTextField.swift in Sources */,
 				31E1E17B24466D28009C4092 /* MorphicBarItem.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -983,6 +1003,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MARKETING_VERSION = 0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.raisingthefloor.Morphic-Debug";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1005,6 +1026,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MARKETING_VERSION = 0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = org.raisingthefloor.Morphic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Morphic Client for macOS";

--- a/Morphic/Morphic/About Box/AboutBoxWindowController.swift
+++ b/Morphic/Morphic/About Box/AboutBoxWindowController.swift
@@ -1,0 +1,89 @@
+// Copyright 2020 Raising the Floor - International
+//
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
+//
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
+//
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
+
+import Cocoa
+
+class AboutBoxWindowController: NSWindowController, NSWindowDelegate {
+
+    private static var singleWindowController: AboutBoxWindowController?
+    
+    @IBOutlet weak var versionTextField: NSTextField!
+    @IBOutlet weak var buildTextField: NSTextField!
+    
+    override var windowNibName: NSNib.Name? {
+        return NSNib.Name("AboutBoxWindowController")
+    }
+    
+    //
+
+    static var single: AboutBoxWindowController {
+        if let singleWindowController = self.singleWindowController {
+            return singleWindowController
+        } else {
+            let aboutBoxWindowController = AboutBoxWindowController()
+            aboutBoxWindowController.window?.delegate = aboutBoxWindowController
+            //
+            AboutBoxWindowController.singleWindowController = aboutBoxWindowController
+            return aboutBoxWindowController
+        }
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        AboutBoxWindowController.singleWindowController = nil
+    }
+
+    //
+    
+    override func windowDidLoad() {
+        super.windowDidLoad()
+
+        // populate the version and build # in our labels
+        if let shortVersionAsString = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+            versionTextField.stringValue = shortVersionAsString
+        } else {
+            assertionFailure("could not retrieve application version #")
+            versionTextField.stringValue = "[version is unknown]"
+        }
+        //
+        // NOTE: for future use: if we incremenet the build version, we can show the build information; for now, just show an empty box
+buildTextField.stringValue = ""
+//        if let buildAsString = Bundle.main.infoDictionary?["CustomBuildInfo" as String] {
+//            buildTextField.stringValue = "(build \(buildAsString))"
+//        } else {
+//            assertionFailure("could not retrieve application build #")
+//            buildTextField.stringValue = "[bundle version is unknown]"
+//        }
+    }
+    
+    func centerOnScreen() {
+        guard let screenFrame = NSScreen.main?.frame else {
+            return
+        }
+        guard let windowFrame = self.window?.frame else {
+            return
+        }
+        
+        let newOrigin = NSPoint(x: (screenFrame.width - windowFrame.width) / 2, y: (screenFrame.height - windowFrame.height) / 2)
+        self.window?.setFrameOrigin(newOrigin)
+    }
+}

--- a/Morphic/Morphic/About Box/AboutBoxWindowController.xib
+++ b/Morphic/Morphic/About Box/AboutBoxWindowController.xib
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="AboutBoxWindowController" customModule="Morphic" customModuleProvider="target">
+            <connections>
+                <outlet property="buildTextField" destination="onK-5c-5rq" id="tFX-mt-jlh"/>
+                <outlet property="versionTextField" destination="Mly-xV-m1p" id="zO1-ty-Lng"/>
+                <outlet property="window" destination="F0z-JX-Cv5" id="gIp-Ho-8D9"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <window title="About Morphic" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" titlebarAppearsTransparent="YES" id="F0z-JX-Cv5">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
+            <rect key="contentRect" x="196" y="240" width="403" height="255"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1792" height="1097"/>
+            <view key="contentView" id="se5-gp-TjO">
+                <rect key="frame" x="0.0" y="0.0" width="403" height="255"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Auq-sw-XnR">
+                        <rect key="frame" x="178" y="159" width="48" height="48"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="48" id="5DY-1f-4K2"/>
+                            <constraint firstAttribute="width" constant="48" id="UtP-N0-LyG"/>
+                        </constraints>
+                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="Icon" id="gFD-l3-ahg"/>
+                    </imageView>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xiq-0B-kHt">
+                        <rect key="frame" x="137" y="112" width="129" height="16"/>
+                        <textFieldCell key="cell" lineBreakMode="clipping" title="Morphic for macOS" id="P3l-Rg-JEz">
+                            <font key="font" metaFont="systemBold"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Mly-xV-m1p">
+                        <rect key="frame" x="177" y="88" width="50" height="16"/>
+                        <textFieldCell key="cell" lineBreakMode="clipping" title="Version" id="rtb-dd-Jkw">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="onK-5c-5rq">
+                        <rect key="frame" x="180" y="64" width="44" height="16"/>
+                        <textFieldCell key="cell" lineBreakMode="clipping" title="(Build)" id="dcf-3V-XXl">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sdd-Te-nD9" customClass="HyperlinkTextField" customModule="Morphic" customModuleProvider="target">
+                        <rect key="frame" x="170" y="42" width="63" height="14"/>
+                        <textFieldCell key="cell" lineBreakMode="clipping" title="Contact Us" id="bKV-Nb-ezu">
+                            <font key="font" metaFont="label" size="11"/>
+                            <color key="textColor" name="linkColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="urlAsString" value="mailto:support@morphic.org"/>
+                        </userDefinedRuntimeAttributes>
+                    </textField>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="Auq-sw-XnR" firstAttribute="top" secondItem="se5-gp-TjO" secondAttribute="top" constant="48" id="0B1-Cy-Qnr"/>
+                    <constraint firstItem="xiq-0B-kHt" firstAttribute="top" secondItem="Auq-sw-XnR" secondAttribute="bottom" constant="31" id="2sD-MW-6St"/>
+                    <constraint firstItem="onK-5c-5rq" firstAttribute="top" secondItem="Mly-xV-m1p" secondAttribute="bottom" constant="8" id="EP9-qv-Zdi"/>
+                    <constraint firstItem="sdd-Te-nD9" firstAttribute="top" secondItem="onK-5c-5rq" secondAttribute="bottom" constant="8" id="Iu0-44-ae0"/>
+                    <constraint firstItem="Auq-sw-XnR" firstAttribute="centerX" secondItem="se5-gp-TjO" secondAttribute="centerX" id="OxA-Yi-Dig"/>
+                    <constraint firstItem="Mly-xV-m1p" firstAttribute="top" secondItem="xiq-0B-kHt" secondAttribute="bottom" constant="8" id="eON-GN-bJG"/>
+                    <constraint firstItem="sdd-Te-nD9" firstAttribute="centerX" secondItem="se5-gp-TjO" secondAttribute="centerX" id="fDB-ff-UAG"/>
+                    <constraint firstItem="Mly-xV-m1p" firstAttribute="centerX" secondItem="se5-gp-TjO" secondAttribute="centerX" id="pbl-0j-0dg"/>
+                    <constraint firstItem="onK-5c-5rq" firstAttribute="centerX" secondItem="se5-gp-TjO" secondAttribute="centerX" id="qEG-A8-ves"/>
+                    <constraint firstItem="xiq-0B-kHt" firstAttribute="centerX" secondItem="se5-gp-TjO" secondAttribute="centerX" id="qfB-CD-GKg"/>
+                </constraints>
+            </view>
+            <connections>
+                <outlet property="delegate" destination="-2" id="0bl-1N-AYu"/>
+            </connections>
+            <point key="canvasLocation" x="100.5" y="139.5"/>
+        </window>
+    </objects>
+    <resources>
+        <image name="Icon" width="512" height="512"/>
+    </resources>
+</document>

--- a/Morphic/Morphic/About Box/HyperlinkTextField.swift
+++ b/Morphic/Morphic/About Box/HyperlinkTextField.swift
@@ -1,0 +1,68 @@
+// Copyright 2020 Raising the Floor - International
+//
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
+//
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
+//
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
+
+import Cocoa
+
+class HyperlinkTextField: NSTextField {
+    @IBInspectable
+    var urlAsString: String? = nil
+    
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+    }
+    
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+
+        // clear out our current tracking areas
+        for trackingArea in trackingAreas {
+            removeTrackingArea(trackingArea)
+        }
+
+        // add a new tracking area equal to our bounds (and capturing our mouseEntered and mouseExited events)
+        let newTrackingArea = NSTrackingArea(rect: self.bounds, options: [.activeAlways, .mouseEnteredAndExited], owner: self, userInfo: nil)
+        addTrackingArea(newTrackingArea)
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        super.mouseEntered(with: event)
+        
+        NSCursor.pointingHand.set()
+    }
+    
+    override func mouseExited(with event: NSEvent) {
+        super.mouseExited(with: event)
+        
+        NSCursor.arrow.set()
+    }
+    
+    override func mouseUp(with event: NSEvent) {
+        super.mouseUp(with: event)
+        
+        if let urlAsString = self.urlAsString {
+            if let url = URL(string: urlAsString) {
+                NSWorkspace.shared.open(url)
+            }
+        }
+    }
+}

--- a/Morphic/Morphic/AppDelegate.swift
+++ b/Morphic/Morphic/AppDelegate.swift
@@ -120,6 +120,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
     }
     
+    @IBAction func showAboutBox(_ sender: NSMenuItem) {
+        let aboutBoxWindowController = AboutBoxWindowController.single
+        if aboutBoxWindowController.window?.isVisible == false {
+            aboutBoxWindowController.centerOnScreen()
+        }
+        
+        aboutBoxWindowController.showWindow(self)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
     // MARK: - Default Preferences
     
     func createEmptyDefaultPreferencesIfNotExist(completion: @escaping () -> Void) {

--- a/Morphic/Morphic/Base.lproj/Main.xib
+++ b/Morphic/Morphic/Base.lproj/Main.xib
@@ -53,6 +53,12 @@
                     </connections>
                 </menuItem>
                 <menuItem isSeparatorItem="YES" id="yYL-r6-1AR"/>
+                <menuItem title="About Morphic..." id="m2n-v5-G3Y">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="showAboutBox:" target="ZNk-5q-oDb" id="wZn-jB-dZm"/>
+                    </connections>
+                </menuItem>
                 <menuItem title="Quit Morphic" keyEquivalent="q" id="aYd-9o-084">
                     <connections>
                         <action selector="terminate:" target="-1" id="oZz-fZ-cJR"/>

--- a/Morphic/Morphic/DefaultPreferences.json
+++ b/Morphic/Morphic/DefaultPreferences.json
@@ -22,7 +22,7 @@
             },
             {
                 "type": "control",
-                "feature": "contrast"
+                "feature": "nightshift"
             }
         ]
     }

--- a/Morphic/Morphic/Info.plist
+++ b/Morphic/Morphic/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Morphic/Morphic/MorphicBar/Base.lproj/MorphicBarViewController.xib
+++ b/Morphic/Morphic/MorphicBar/Base.lproj/MorphicBarViewController.xib
@@ -80,6 +80,12 @@
                     </connections>
                 </menuItem>
                 <menuItem isSeparatorItem="YES" id="vgL-Lb-axj"/>
+                <menuItem title="About Morphic..." id="GjN-rN-rcZ">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="showAboutBox:" target="-1" id="iCU-gX-DgC"/>
+                    </connections>
+                </menuItem>
                 <menuItem title="Quit Morphic" keyEquivalent="q" id="tHP-m8-Lto">
                     <connections>
                         <action selector="terminate:" target="-1" id="AxL-78-D9D"/>

--- a/Morphic/Morphic/MorphicBar/MorphicBarItem.swift
+++ b/Morphic/Morphic/MorphicBar/MorphicBarItem.swift
@@ -69,6 +69,7 @@ class MorphicBarControlItem: MorphicBarItem{
         case reader
         case volume
         case contrast
+        case nightshift
         case unknown
         
         init(string: String?) {
@@ -149,6 +150,19 @@ class MorphicBarControlItem: MorphicBarItem{
             view.segmentedButton.target = self
             view.segmentedButton.action = #selector(MorphicBarControlItem.contrast(_:))
             return view
+        case .nightshift:
+            let localized = LocalizedStrings(prefix: "control.feature.nightshift")
+            let onHelpProvider = QuickHelpDynamicTextProvider{ (title: localized.string(for: "on.help.title"), message: localized.string(for: "on.help.message")) }
+            let offHelpProvider = QuickHelpDynamicTextProvider{ (title: localized.string(for: "off.help.title"), message: localized.string(for: "off.help.message")) }
+            let segments = [
+                MorphicBarSegmentedButton.Segment(title: localized.string(for: "on"), isPrimary: true, helpProvider: onHelpProvider),
+                MorphicBarSegmentedButton.Segment(title: localized.string(for: "off"), isPrimary: false, helpProvider: offHelpProvider)
+            ]
+            let view = MorphicBarSegmentedButtonItemView(title: localized.string(for: "title"), segments: segments)
+            view.segmentedButton.contentInsets = NSEdgeInsets(top: 7, left: 14, bottom: 7, right: 14)
+            view.segmentedButton.target = self
+            view.segmentedButton.action = #selector(MorphicBarControlItem.nightShift(_:))
+            return view
         default:
             return nil
         }
@@ -211,7 +225,19 @@ class MorphicBarControlItem: MorphicBarItem{
             }
         }
     }
-    
+
+    @objc
+    func nightShift(_ sender: Any?) {
+        guard let segment = (sender as? MorphicBarSegmentedButton)?.integerValue else {
+            return
+        }
+        if segment == 0 {
+            MorphicNightShift.setEnabled(true)
+        } else {
+            MorphicNightShift.setEnabled(false)
+        }
+    }
+
     @objc
     func reader(_ sender: Any?) {
         guard let segment = (sender as? MorphicBarSegmentedButton)?.integerValue else {

--- a/Morphic/Morphic/MorphicBar/MorphicBarItem.swift
+++ b/Morphic/Morphic/MorphicBar/MorphicBarItem.swift
@@ -155,8 +155,8 @@ class MorphicBarControlItem: MorphicBarItem{
             let onHelpProvider = QuickHelpDynamicTextProvider{ (title: localized.string(for: "on.help.title"), message: localized.string(for: "on.help.message")) }
             let offHelpProvider = QuickHelpDynamicTextProvider{ (title: localized.string(for: "off.help.title"), message: localized.string(for: "off.help.message")) }
             let segments = [
-                MorphicBarSegmentedButton.Segment(title: localized.string(for: "on"), isPrimary: true, helpProvider: onHelpProvider),
-                MorphicBarSegmentedButton.Segment(title: localized.string(for: "off"), isPrimary: false, helpProvider: offHelpProvider)
+                MorphicBarSegmentedButton.Segment(title: localized.string(for: "on"), isPrimary: true, helpProvider: onHelpProvider, accessibilityLabel: localized.string(for: "on.help.title")),
+                MorphicBarSegmentedButton.Segment(title: localized.string(for: "off"), isPrimary: false, helpProvider: offHelpProvider, accessibilityLabel: localized.string(for: "off.help.title"))
             ]
             let view = MorphicBarSegmentedButtonItemView(title: localized.string(for: "title"), segments: segments)
             view.segmentedButton.contentInsets = NSEdgeInsets(top: 7, left: 14, bottom: 7, right: 14)

--- a/Morphic/Morphic/MorphicBar/MorphicBarSegmentedButton.swift
+++ b/Morphic/Morphic/MorphicBar/MorphicBarSegmentedButton.swift
@@ -117,6 +117,8 @@ class MorphicBarSegmentedButton: NSControl {
     
     // MARK: - Layout
     
+    let horizontalMarginBetweenSegments = CGFloat(1.5)
+    
     override var isFlipped: Bool {
         return true
     }
@@ -137,6 +139,7 @@ class MorphicBarSegmentedButton: NSControl {
             let buttonSize = button.intrinsicContentSize
             size.width += buttonSize.width
         }
+        size.width += CGFloat(max(segmentButtons.count - 1, 0)) * horizontalMarginBetweenSegments
         return size
     }
     
@@ -146,7 +149,7 @@ class MorphicBarSegmentedButton: NSControl {
             let buttonSize = button.intrinsicContentSize
             frame.size.width = buttonSize.width
             button.frame = frame
-            frame.origin.x += frame.size.width
+            frame.origin.x += frame.size.width + horizontalMarginBetweenSegments
         }
     }
     
@@ -264,7 +267,9 @@ class MorphicBarSegmentedButton: NSControl {
         }
         button.setAccessibilityLabel(segment.accessibilityLabel)
         button.helpProvider = segment.helpProvider
-        (button.cell as? NSButtonCell)?.backgroundColor = segment.isPrimary ? primarySegmentColor : secondarySegmentColor
+        (button.cell as? NSButtonCell)?.backgroundColor = primarySegmentColor
+        // NOTE: to use two alternating (contrasting) colors, uncomment the following line and set horizontalMarginBetweenSegments to 0.
+//        (button.cell as? NSButtonCell)?.backgroundColor = segment.isPrimary ? primarySegmentColor : secondarySegmentColor
         button.font = font
         return button
     }

--- a/Morphic/Morphic/MorphicBar/en.lproj/MorphicBarViewController.strings
+++ b/Morphic/Morphic/MorphicBar/en.lproj/MorphicBarViewController.strings
@@ -160,3 +160,24 @@
 
 /* Message for the help window for the hide magnifier button */
 "control.feature.contrast.off.help.message" = "Make it harder to distinguish items";
+
+/* Label for the buttons that control night mode */
+"control.feature.nightshift.title" = "Night Mode";
+
+/* Label for the button that turns night mode on */
+"control.feature.nightshift.on" = "On";
+
+/* Title for the help window for the 'turn on night mode' button */
+"control.feature.nightshift.on.help.title" = "Turn On Night Mode";
+
+/* Message for the help window for the 'turn on night mode' button */
+"control.feature.nightshift.on.help.message" = "Make screen colors warmer for better sleep";
+
+/* Label for the button that turns night mode off */
+"control.feature.nightshift.off" = "Off";
+
+/* Title for the help window for the 'turn off night mode' button */
+"control.feature.nightshift.off.help.title" = "Turn Off Night Mode";
+
+/* Message for the help window for the 'turn off night mode' button */
+"control.feature.nightshift.off.help.message" = "Make screen colors less warm for daytime";

--- a/MorphicSettings/MorphicSettings.xcodeproj/project.pbxproj
+++ b/MorphicSettings/MorphicSettings.xcodeproj/project.pbxproj
@@ -50,6 +50,9 @@
 		31A16BD22423E86C0081A72C /* MorphicWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A16BCA2423E86C0081A72C /* MorphicWindow.swift */; };
 		31CE56E22448C8F700A52A7B /* SettingHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31CE56E12448C8F700A52A7B /* SettingHandler.swift */; };
 		31CE56EB244A149B00A52A7B /* Audio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31CE56EA244A149B00A52A7B /* Audio.swift */; };
+		9D0AF77324A460A9007E177E /* CoreBrightness.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D0AF77224A460A9007E177E /* CoreBrightness.framework */; };
+		9D0AF77724A4616E007E177E /* MorphicNightShift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D0AF77624A4616E007E177E /* MorphicNightShift.swift */; };
+		9D59F47E24A6B3040004C35B /* CBBlueLightClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D0AF77524A4613D007E177E /* CBBlueLightClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		31F9AEDD24A7F2D90026EBDA /* AccessibilityUIAutomation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F9AEDC24A7F2D90026EBDA /* AccessibilityUIAutomation.swift */; };
 		31F9AEE324A7F7EA0026EBDA /* VoiceOverUIAutomations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F9AEE224A7F7EA0026EBDA /* VoiceOverUIAutomations.swift */; };
 		31F9AEE524A803B90026EBDA /* ZoomUIAutomations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F9AEE424A803B90026EBDA /* ZoomUIAutomations.swift */; };
@@ -133,6 +136,10 @@
 		31A16BCA2423E86C0081A72C /* MorphicWindow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MorphicWindow.swift; sourceTree = "<group>"; };
 		31CE56E12448C8F700A52A7B /* SettingHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingHandler.swift; sourceTree = "<group>"; };
 		31CE56EA244A149B00A52A7B /* Audio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Audio.swift; sourceTree = "<group>"; };
+		9D0AF77224A460A9007E177E /* CoreBrightness.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreBrightness.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/PrivateFrameworks/CoreBrightness.framework; sourceTree = DEVELOPER_DIR; };
+		9D0AF77524A4613D007E177E /* CBBlueLightClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBBlueLightClient.h; sourceTree = "<group>"; };
+		9D0AF77624A4616E007E177E /* MorphicNightShift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MorphicNightShift.swift; sourceTree = "<group>"; };
+		9D0AF78924A4F471007E177E /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		31F9AEDC24A7F2D90026EBDA /* AccessibilityUIAutomation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityUIAutomation.swift; sourceTree = "<group>"; };
 		31F9AEE224A7F7EA0026EBDA /* VoiceOverUIAutomations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOverUIAutomations.swift; sourceTree = "<group>"; };
 		31F9AEE424A803B90026EBDA /* ZoomUIAutomations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomUIAutomations.swift; sourceTree = "<group>"; };
@@ -151,6 +158,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9D0AF77324A460A9007E177E /* CoreBrightness.framework in Frameworks */,
 				311336542427FB3400686AF6 /* MorphicCore.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -169,6 +177,7 @@
 		311336522427FB3400686AF6 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				9D0AF77224A460A9007E177E /* CoreBrightness.framework */,
 				311336532427FB3400686AF6 /* MorphicCore.framework */,
 			);
 			name = Frameworks;
@@ -282,6 +291,7 @@
 				312DBFFA24A2C66A002FB951 /* ApplySession.swift */,
 				311336502427F33600686AF6 /* Display.swift */,
 				31CE56EA244A149B00A52A7B /* Audio.swift */,
+				9D0AF78924A4F471007E177E /* module.modulemap */,
 				315EEC8224A530970039C61D /* SystemPreferences.swift */,
 			);
 			path = MorphicSettings;
@@ -332,7 +342,9 @@
 		31A16BC52423E86C0081A72C /* Display */ = {
 			isa = PBXGroup;
 			children = (
+				9D0AF77424A46131007E177E /* include */,
 				31A16BC62423E86C0081A72C /* MorphicDisplay.swift */,
+				9D0AF77624A4616E007E177E /* MorphicNightShift.swift */,
 			);
 			path = Display;
 			sourceTree = "<group>";
@@ -351,6 +363,14 @@
 				31A16BCA2423E86C0081A72C /* MorphicWindow.swift */,
 			);
 			path = Window;
+			sourceTree = "<group>";
+		};
+		9D0AF77424A46131007E177E /* include */ = {
+			isa = PBXGroup;
+			children = (
+				9D0AF77524A4613D007E177E /* CBBlueLightClient.h */,
+			);
+			path = include;
 			sourceTree = "<group>";
 		};
 		9D0AF73524A0FB49007E177E /* AccessibilityUI */ = {
@@ -389,6 +409,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				31A0A5882405967600166668 /* MorphicSettings.h in Headers */,
+				9D59F47E24A6B3040004C35B /* CBBlueLightClient.h in Headers */,
 				31F9AEE924A80C7C0026EBDA /* KeyEvents.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -501,6 +522,7 @@
 				31A16BD12423E86C0081A72C /* MorphicAudio.swift in Sources */,
 				315EEC9724A56DF20039C61D /* AccessibilityPreferencesElement.swift in Sources */,
 				312DBFFD24A2C683002FB951 /* CaptureSession.swift in Sources */,
+				9D0AF77724A4616E007E177E /* MorphicNightShift.swift in Sources */,
 				31A16BCC2423E86C0081A72C /* MorphicProcess.swift in Sources */,
 				31F9AEEA24A80C7C0026EBDA /* KeyEvents.m in Sources */,
 				315EEC9124A547B70039C61D /* WindowElement.swift in Sources */,
@@ -695,6 +717,11 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks",
+					"$(PROJECT_DIR)",
+				);
 				INFOPLIST_FILE = MorphicSettings/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -702,6 +729,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MODULEMAP_FILE = MorphicSettings/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = org.raisingthefloor.MorphicSettings;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -723,6 +751,11 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks",
+					"$(PROJECT_DIR)",
+				);
 				INFOPLIST_FILE = MorphicSettings/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -730,6 +763,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MODULEMAP_FILE = MorphicSettings/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = org.raisingthefloor.MorphicSettings;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/MorphicSettings/MorphicSettings/Display/MorphicNightShift.swift
+++ b/MorphicSettings/MorphicSettings/Display/MorphicNightShift.swift
@@ -1,0 +1,143 @@
+// Copyright 2020 Raising the Floor - International
+//
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
+//
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
+//
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
+
+import Foundation
+
+public struct MorphicNightShift {
+    public enum NightShiftScheduleMode: Int {
+        case off = 0
+        case sunsetToSunrise = 1
+        case custom = 2
+    }
+
+    public struct NightShiftSchedule {
+        public let from: (hour: Int, minute: Int)
+        public let to: (hour: Int, minute: Int)
+        
+        public init(from: (hour: Int, minute: Int), to: (hour: Int, minute: Int)) {
+            self.from = from
+            self.to = to
+        }
+    }
+
+    // NOTE: "active" means that the feature is allowed; if active==false then ENABLED has no effect
+    public static func getActive() -> Bool {
+        let blueLightClient = CBBlueLightClient()
+        
+        var blueLightStatus = CBBlueLight_Status()
+        blueLightClient.getBlueLightStatus(&blueLightStatus)
+        
+        return blueLightStatus.active.boolValue
+    }
+    //
+    public static func setActive(_ active: Bool) {
+        let blueLightClient = CBBlueLightClient()
+        blueLightClient.setActive(active)
+    }
+    
+    public static func getLocationPermissionGranted() -> Bool {
+        let blueLightClient = CBBlueLightClient()
+        
+        var blueLightStatus = CBBlueLight_Status()
+        blueLightClient.getBlueLightStatus(&blueLightStatus)
+        
+        return blueLightStatus.locationPermissionGranted.boolValue
+    }
+
+    // NOTE: "enabled" means that the feature is currently in effect; however if active==false then ENABLED has no effect
+    // NOTE: the "enabled" state corresponds to the "Manual" checkbox in System Preferences > ... > Night Shift (but "manual" is really a toggle, auto-updated if triggered by sunset/sunrise)
+    public static func getEnabled() -> Bool {
+        let blueLightClient = CBBlueLightClient()
+        
+        var blueLightStatus = CBBlueLight_Status()
+        blueLightClient.getBlueLightStatus(&blueLightStatus)
+        
+        return blueLightStatus.enabled.boolValue
+    }
+    //
+    public static func setEnabled(_ enabled: Bool) {
+        let blueLightClient = CBBlueLightClient()
+        blueLightClient.setEnabled(enabled)
+    }
+
+    public static func getScheduleMode() -> NightShiftScheduleMode? {
+        let blueLightClient = CBBlueLightClient()
+        
+        var blueLightStatus = CBBlueLight_Status()
+        blueLightClient.getBlueLightStatus(&blueLightStatus)
+        
+        return NightShiftScheduleMode(rawValue: Int(blueLightStatus.mode))
+    }
+    //
+    public static func setScheduleMode(_ mode: NightShiftScheduleMode) {
+        let blueLightClient = CBBlueLightClient()
+        blueLightClient.setMode(Int32(mode.rawValue))
+    }
+
+    public static func getSchedule() -> NightShiftSchedule {
+        let blueLightClient = CBBlueLightClient()
+        
+        var blueLightStatus = CBBlueLight_Status()
+        blueLightClient.getBlueLightStatus(&blueLightStatus)
+        
+        let result = NightShiftSchedule(
+            from: (hour: Int(blueLightStatus.schedule.from.hour), minute: Int(blueLightStatus.schedule.from.minute)),
+            to: (hour: Int(blueLightStatus.schedule.to.hour), minute: Int(blueLightStatus.schedule.to.minute))
+        )
+        return result
+    }
+    //
+    public static func setSchedule(_ schedule: NightShiftSchedule) {
+        precondition(schedule.from.hour >= 0 && schedule.from.hour <= 23, "Argument 'schedule.from.hour' is out of the allowed range 0...23")
+        precondition(schedule.from.minute >= 0 && schedule.from.minute <= 59, "Argument 'schedule.from.minute' is out of the allowed range 0...59")
+        precondition(schedule.to.hour >= 0 && schedule.to.hour <= 23, "Argument 'schedule.to.hour' is out of the allowed range 0...23")
+        precondition(schedule.to.minute >= 0 && schedule.to.minute <= 59, "Argument 'schedule.to.minute' is out of the allowed range 0...59")
+
+        let blueLightClient = CBBlueLightClient()
+        
+        var schedule = CBBlueLight_Schedule(
+            from: CBBlueLight_ScheduleTime(hour: Int32(schedule.from.hour), minute: Int32(schedule.from.minute)),
+            to: CBBlueLight_ScheduleTime(hour: Int32(schedule.to.hour), minute: Int32(schedule.to.minute))
+        )
+        blueLightClient.setSchedule(&schedule)
+    }
+
+    public static func getColorTemperature() -> Float {
+        let blueLightClient = CBBlueLightClient()
+        
+        var strength = Float()
+        blueLightClient.getStrength(&strength)
+        
+        return strength
+    }
+
+    // NOTE: if "overrideEnabled" is set to true, then the color temperature will go into effect even if "enabled == false"
+    public static func setColorTemperature(_ value: Float, overrideEnabled: Bool = false) {
+        let blueLightClient = CBBlueLightClient()
+        
+        // NOTE: "commit = true" saves the setting but only makes it effective if night shift is currently enabled (i.e. if "enabled == true"); this is useful if we are demonstrating what a color temperature effect would be to the user in a dialog
+        // NOTE: "commit = false" saves the setting and makes it effective regardless of whether night shift is currently enabled
+        let commit = !overrideEnabled
+        blueLightClient.setStrength(value, commit: commit)
+    }
+}

--- a/MorphicSettings/MorphicSettings/Display/include/CBBlueLightClient.h
+++ b/MorphicSettings/MorphicSettings/Display/include/CBBlueLightClient.h
@@ -1,0 +1,62 @@
+// Copyright 2020 Raising the Floor - International
+//
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
+//
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
+//
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
+
+// NOTE: this is a partially-reverse-engineered header (i.e. not the complete original header)
+//
+// Tools: nm; Ghidra; RuntimeBrowser; manual analysis
+// Path: /System/Library/PrivateFrameworks/CoreBrightness.framework/CoreBrightness
+// OS: macOS 10.15.5
+
+#import <Foundation/Foundation.h>
+
+@interface CBBlueLightClient : NSObject
+
+typedef struct {
+    int hour;
+    int minute;
+} CBBlueLight_ScheduleTime;
+
+typedef struct {
+    CBBlueLight_ScheduleTime from;
+    CBBlueLight_ScheduleTime to;
+} CBBlueLight_Schedule;
+
+typedef struct {
+    BOOL active;
+    BOOL enabled;
+    BOOL locationPermissionGranted;
+    int mode;
+    CBBlueLight_Schedule schedule;
+    unsigned long long unknown1;
+    BOOL unknown2;
+} CBBlueLight_Status;
+
+- (BOOL)getBlueLightStatus:(CBBlueLight_Status *)status;
+- (BOOL)getStrength:(float*)strength;
+- (BOOL)setActive:(BOOL)active;
+- (BOOL)setEnabled:(BOOL)enabled;
+- (BOOL)setMode:(int)mode;
+- (BOOL)setSchedule:(const CBBlueLight_Schedule*)schedule;
+- (BOOL)setStrength:(float)strength commit:(BOOL)commit;
+
+@end

--- a/MorphicSettings/MorphicSettings/module.modulemap
+++ b/MorphicSettings/MorphicSettings/module.modulemap
@@ -1,0 +1,30 @@
+// Copyright 2020 Raising the Floor - International
+//
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
+//
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
+//
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
+
+framework module MorphicSettings {
+    umbrella header "MorphicSettings.h"
+
+    header "CBBlueLightClient.h"
+
+    export *
+}


### PR DESCRIPTION
JIRA ticket: MOR-87

I added a manual "nightmode" button to turn on/off macOS's night shift feature.

Since this is an intermittent "on/off" feature (much like muting/unmuting the volume), I did not add a settings handler.  But if we'd like to do that, we can do that too.

Please note that the hover-over text has NOT yet been written.  I used some filler text--but we should wait until the official text is approved (and checked in) before merging this to master.

NOTE: this PR is branched from the feature/christopher-night-shift branch, not master.