### PR TITLE
Change MorphicBar "Screen Reader" button to "Read Selected"

### DIFF
--- a/Morphic/Morphic/AppDelegate.swift
+++ b/Morphic/Morphic/AppDelegate.swift
@@ -52,7 +52,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             Session.shared.open {
                 os_log(.info, log: logger, "session open")
                 self.logoutItem?.isHidden = Session.shared.user == nil
-                if Session.shared.bool(for: .morphicBarVisible) ?? true{
+                if Session.shared.bool(for: .morphicBarVisible) ?? true {
                     self.showMorphicBar(nil)
                 }
                 DistributedNotificationCenter.default().addObserver(self, selector: #selector(AppDelegate.userDidSignin), name: .morphicSignin, object: nil)

--- a/Morphic/Morphic/DefaultPreferences.json
+++ b/Morphic/Morphic/DefaultPreferences.json
@@ -14,7 +14,7 @@
             },
             {
                 "type": "control",
-                "feature": "reader"
+                "feature": "readselected"
             },
             {
                 "type": "control",

--- a/Morphic/Morphic/MorphicBar/MorphicBarItem.swift
+++ b/Morphic/Morphic/MorphicBar/MorphicBarItem.swift
@@ -266,7 +266,10 @@ class MorphicBarControlItem: MorphicBarItem{
             let keyOptions: MorphicInput.KeyOptions
             if speakSelectedTextHotKeyCombo != 0 {
                 guard let (customKeyCode, customKeyOptions) = MorphicInput.parseDefaultsKeyCombo(speakSelectedTextHotKeyCombo) else {
-                    fatalError("could not decode key; be sure to log the error or let the user know")
+                    // NOTE: while we should be able to decode any custom hotkey, this code is here to capture edge cases we have not anticipated
+                    // NOTE: in the future, we should consider an informational prompt alerting the user that we could not decode their custom hotkey (so they know why the feature did not work...or at least that it intentionally did not work)
+                    NSLog("Could not decode custom hotkey")
+                    return
                 }
                 keyCode = customKeyCode
                 keyOptions = customKeyOptions

--- a/Morphic/Morphic/MorphicBar/en.lproj/MorphicBarViewController.strings
+++ b/Morphic/Morphic/MorphicBar/en.lproj/MorphicBarViewController.strings
@@ -168,8 +168,8 @@
 "control.feature.readselected.playstop" = "\U25B6 / \U25A0";
 
 /* Title for the help window for the play/stop 'read selected text' button */
-"control.feature.readselected.playstop.help.title" = "Play/Pause Selected Text";
+"control.feature.readselected.playstop.help.title" = "Read/Stop Reading Selected Text";
 
 /* Message for the help window for the play/stop 'read selected text' button */
-"control.feature.readselected.playstop.help.message" = "Read the selected text in the active application";
+"control.feature.readselected.playstop.help.message" = "How to use: Select text and then click this button to have it read to you. Click again to stop.";
 

--- a/Morphic/Morphic/MorphicBar/en.lproj/MorphicBarViewController.strings
+++ b/Morphic/Morphic/MorphicBar/en.lproj/MorphicBarViewController.strings
@@ -160,3 +160,16 @@
 
 /* Message for the help window for the hide magnifier button */
 "control.feature.contrast.off.help.message" = "Make it harder to distinguish items";
+
+/* Label for the buttons that play/stop 'read selected text' */
+"control.feature.readselected.title" = "Read Selected";
+
+/* Label for the button that plays/stops 'read selected text' */
+"control.feature.readselected.playstop" = "\U25B6 / \U25A0";
+
+/* Title for the help window for the play/stop 'read selected text' button */
+"control.feature.readselected.playstop.help.title" = "Play/Pause Selected Text";
+
+/* Message for the help window for the play/stop 'read selected text' button */
+"control.feature.readselected.playstop.help.message" = "Read the selected text in the active application";
+

--- a/Morphic/Morphic/Solutions/macos.solutions.json
+++ b/Morphic/Morphic/Solutions/macos.solutions.json
@@ -139,6 +139,23 @@
     ]
   },
   {
+    "id": "com.apple.macos.speech",
+    "settings": [
+      {
+        "name": "speakselectedtext.enabled",
+        "type": "boolean",
+        "default": false,
+        "handler": {
+          "type": "com.apple.macos.defaults-read-ui-write",
+          "defaults_domain": "com.apple.speech.synthesis.general.prefs",
+          "defaults_key": "SpokenUIUseSpeakingHotKeyFlag",
+          "solution": "com.apple.macos.speech",
+          "preference": "speakselectedtext.enabled"
+        }
+      }
+    ]
+  },
+  {
     "id": "com.apple.macos.voiceover",
     "settings": [
       {

--- a/MorphicSettings/MorphicSettings.xcodeproj/project.pbxproj
+++ b/MorphicSettings/MorphicSettings.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		9D0AF73924A0FB78007E177E /* MorphicA11yUIElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D0AF73824A0FB78007E177E /* MorphicA11yUIElement.swift */; };
 		9D5EC22C24927EFD00AC77B5 /* MorphicPropertyList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D5EC22B24927EFD00AC77B5 /* MorphicPropertyList.swift */; };
 		9DCE209224CF1AAF00D3445B /* MorphicA11yAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCE209124CF1AAF00D3445B /* MorphicA11yAuthorization.swift */; };
+		9DD22FBA24DCB8B800C2FA52 /* SpeechUIAutomations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DD22FB924DCB8B800C2FA52 /* SpeechUIAutomations.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -151,6 +152,7 @@
 		9D0AF73824A0FB78007E177E /* MorphicA11yUIElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MorphicA11yUIElement.swift; sourceTree = "<group>"; };
 		9D5EC22B24927EFD00AC77B5 /* MorphicPropertyList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MorphicPropertyList.swift; sourceTree = "<group>"; };
 		9DCE209124CF1AAF00D3445B /* MorphicA11yAuthorization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MorphicA11yAuthorization.swift; sourceTree = "<group>"; };
+		9DD22FB924DCB8B800C2FA52 /* SpeechUIAutomations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechUIAutomations.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -200,6 +202,7 @@
 				314EB6DF24A6A69B00CF3D48 /* DisplayUIAutomations.swift */,
 				31F9AEE224A7F7EA0026EBDA /* VoiceOverUIAutomations.swift */,
 				31F9AEE424A803B90026EBDA /* ZoomUIAutomations.swift */,
+				9DD22FB924DCB8B800C2FA52 /* SpeechUIAutomations.swift */,
 			);
 			path = Automations;
 			sourceTree = "<group>";
@@ -554,6 +557,7 @@
 				9D0AF73724A0FB67007E177E /* MorphicA11yUIAttributeValueCompatible.swift in Sources */,
 				31CE56E22448C8F700A52A7B /* SettingHandler.swift in Sources */,
 				315EEC8724A536A60039C61D /* TabGroupElement.swift in Sources */,
+				9DD22FBA24DCB8B800C2FA52 /* SpeechUIAutomations.swift in Sources */,
 				3137AC4224B0FB9600CE3808 /* MenuElement.swift in Sources */,
 				315EEC9924A5714F0039C61D /* RowElement.swift in Sources */,
 				314EB6E024A6A69B00CF3D48 /* DisplayUIAutomations.swift in Sources */,

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/SystemPrefs/AccessibilityPreferencesElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/SystemPrefs/AccessibilityPreferencesElement.swift
@@ -28,18 +28,21 @@ public class AccessibilityPreferencesElement: UIElement {
     public enum CategoryIdentifier {
         
         case display
-        case zoom
+        case speech
         case voiceOver
-        
+        case zoom
+
         public var rowTitle: String {
             get{
                 switch self {
                 case .display:
                     return "Display"
-                case .zoom:
-                    return "Zoom"
+                case .speech:
+                    return "Speech"
                 case .voiceOver:
                     return "VoiceOver"
+                case .zoom:
+                    return "Zoom"
                 }
             }
         }
@@ -53,7 +56,7 @@ public class AccessibilityPreferencesElement: UIElement {
     public func selectDisplay(completion: @escaping (_ success: Bool) -> Void) {
         select(category: .display) {
             success in
-            guard success else{
+            guard success else {
                 completion(false)
                 return
             }
@@ -63,11 +66,25 @@ public class AccessibilityPreferencesElement: UIElement {
             }
         }
     }
-    
+
+    public func selectSpeech(completion: @escaping (_ success: Bool) -> Void) {
+        select(category: .speech) {
+            success in
+            guard success else {
+                completion(false)
+                return
+            }
+            self.wait(atMost: 1.0, for: { self.checkbox(titled: "Enable announcements") != nil}) {
+                success in
+                completion(success)
+            }
+        }
+    }
+
     public func selectVoiceOver(completion: @escaping (_ success: Bool) -> Void) {
         select(category: .voiceOver) {
             success in
-            guard success else{
+            guard success else {
                 completion(false)
                 return
             }

--- a/MorphicSettings/MorphicSettings/Automations/AccessibilityUIAutomation.swift
+++ b/MorphicSettings/MorphicSettings/Automations/AccessibilityUIAutomation.swift
@@ -81,7 +81,26 @@ public class AccessibilityUIAutomation: UIAutomation {
             }
         }
     }
-    
+
+    public func showAccessibilitySpeechPreferences(completion: @escaping (_ accessibility: AccessibilityPreferencesElement?) -> Void){
+        showAccessibilityPreferences {
+            accessibility in
+            guard let accessibility = accessibility else {
+                completion(nil)
+                return
+            }
+            accessibility.selectSpeech {
+                success in
+                guard success else {
+                    os_log(.error, log: logger, "Failed to select Speech category")
+                    completion(nil)
+                    return
+                }
+                completion(accessibility)
+            }
+        }
+    }
+
     public func showAccessibilityVoiceOverPreferences(completion: @escaping (_ accessibility: AccessibilityPreferencesElement?) -> Void){
         showAccessibilityPreferences {
             accessibility in
@@ -91,7 +110,7 @@ public class AccessibilityUIAutomation: UIAutomation {
             }
             accessibility.selectVoiceOver {
                 success in
-                guard success else{
+                guard success else {
                     os_log(.error, log: logger, "Failed to select VoiceOver category")
                     completion(nil)
                     return

--- a/MorphicSettings/MorphicSettings/Automations/SpeechUIAutomations.swift
+++ b/MorphicSettings/MorphicSettings/Automations/SpeechUIAutomations.swift
@@ -1,0 +1,67 @@
+// Copyright 2020 Raising the Floor - International
+//
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
+//
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
+//
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
+
+//import Cocoa
+import MorphicCore
+import OSLog
+
+private let logger = OSLog(subsystem: "MorphicSettings", category: "SpeechUIAutomations")
+
+public class SpeechCheckboxUIAutomation: AccessibilityUIAutomation {
+
+    var checkboxTitle: String! { nil }
+
+    public override func apply(_ value: Interoperable?, completion: @escaping (Bool) -> Void) {
+        guard let checked = value as? Bool else {
+            os_log(.error, log: logger, "Passed non-boolean value")
+            completion(false)
+            return
+        }
+        showAccessibilitySpeechPreferences {
+            accessibility in
+            guard let accessibility = accessibility else {
+                completion(false)
+                return
+            }
+            guard let checkbox = accessibility.checkbox(titled: self.checkboxTitle) else {
+                os_log(.error, log: logger, "Failed to find checkbox")
+                completion(false)
+                return
+            }
+            guard checkbox.setChecked(checked) else {
+                os_log(.error, log: logger, "Failed to check checkbox")
+                completion(false)
+                return
+            }
+            completion(true)
+        }
+
+    }
+
+}
+
+public class SpeakSelectedTextEnabledUIAutomation: SpeechCheckboxUIAutomation {
+
+    override var checkboxTitle: String! { "Speak selected text when the key is pressed" }
+
+}

--- a/MorphicSettings/MorphicSettings/Automations/ZoomUIAutomations.swift
+++ b/MorphicSettings/MorphicSettings/Automations/ZoomUIAutomations.swift
@@ -61,7 +61,7 @@ public class ZoomCheckboxUIAutomation: AccessibilityUIAutomation {
     
 }
 
-public class ZoomPopupButtonUIAutomation: AccessibilityUIAutomation{
+public class ZoomPopupButtonUIAutomation: AccessibilityUIAutomation {
     
     var buttonTitle: String! { nil }
     

--- a/MorphicSettings/MorphicSettings/DefaultsReadUIWriteSettingHandler.swift
+++ b/MorphicSettings/MorphicSettings/DefaultsReadUIWriteSettingHandler.swift
@@ -29,9 +29,8 @@ private let logger = OSLog(subsystem: "MorphicSettings", category: "DefaultsRead
 
 /// A setting handler that reads values from user defaults, but writes values using the system preferences UI
 ///
-/// The asymmetry between read and write is because macOS won't let us write the user defaults directly.
-/// Additionally, several system settings checkboxes actually change more than one default and call private
-/// functions that we don't have access to, so using the UI is the best option.
+/// The asymmetry between read and write is because macOS won't let us write the user defaults directly (sometimes because we don't have Full Trust, sometimes because of SIP).
+/// Additionally, several system settings checkboxes actually change more than one default and call private functions that we don't have access to, so using the UI is the best option.
 public class DefaultsReadUIWriteSettingHandler: SettingHandler {
     
     public required init(setting: Setting) {

--- a/MorphicSettings/MorphicSettings/SettingsManager.swift
+++ b/MorphicSettings/MorphicSettings/SettingsManager.swift
@@ -47,6 +47,9 @@ public class SettingsManager {
         DefaultsReadUIWriteSettingHandler.register(automation: ColorFilterEnabledAutomation.self, for: .macosColorFilterEnabled)
         DefaultsReadUIWriteSettingHandler.register(automation: ColorFilterTypeAutomation.self, for: .macosColorFilterType)
         DefaultsReadUIWriteSettingHandler.register(automation: ColorFilterIntensityUIAutomation.self, for: .macosColorFilterIntensity)
+
+        // Speech
+        DefaultsReadUIWriteSettingHandler.register(automation: SpeakSelectedTextEnabledUIAutomation.self, for: .macosSpeakSelectedTextEnabled)
         
         // Voice Over
         DefaultsReadUIWriteSettingHandler.register(automation: VoiceOverUIAutomation.self, for: .macosVoiceOverEnabled)
@@ -157,6 +160,9 @@ public extension Preferences.Key {
     static var macosColorFilterEnabled = Preferences.Key(solution: "com.apple.macos.display", preference: "colorfilter.enabled")
     static var macosColorFilterType = Preferences.Key(solution: "com.apple.macos.display", preference: "colorfilter.type")
     static var macosColorFilterIntensity = Preferences.Key(solution: "com.apple.macos.display", preference: "colorfilter.intensity")
+    
+    // Speech
+    static var macosSpeakSelectedTextEnabled = Preferences.Key(solution: "com.apple.macos.speech", preference: "speakselectedtext.enabled")
     
     // Voice Over
     static var macosVoiceOverEnabled = Preferences.Key(solution: "com.apple.macos.voiceover", preference: "enabled")

--- a/MorphicSettings/MorphicSettings/SettingsManager.swift
+++ b/MorphicSettings/MorphicSettings/SettingsManager.swift
@@ -34,6 +34,7 @@ public class SettingsManager {
     public static var shared: SettingsManager = SettingsManager()
     
     private init() {
+        // Display
         ClientSettingHandler.register(type: DisplayZoomHandler.self, for: .macosDisplayZoom)
         DefaultsReadUIWriteSettingHandler.register(automation: ContrastUIAutomation.self, for: .macosDisplayContrastEnabled)
         DefaultsReadUIWriteSettingHandler.register(automation: InvertColorsUIAutomation.self, for: .macosDisplayInvertColors)
@@ -47,8 +48,10 @@ public class SettingsManager {
         DefaultsReadUIWriteSettingHandler.register(automation: ColorFilterTypeAutomation.self, for: .macosColorFilterType)
         DefaultsReadUIWriteSettingHandler.register(automation: ColorFilterIntensityUIAutomation.self, for: .macosColorFilterIntensity)
         
+        // Voice Over
         DefaultsReadUIWriteSettingHandler.register(automation: VoiceOverUIAutomation.self, for: .macosVoiceOverEnabled)
         
+        // Zoom
         DefaultsReadUIWriteSettingHandler.register(automation: ZoomEnabledUIAutomation.self, for: .macosZoomEnabled)
         DefaultsReadUIWriteSettingHandler.register(automation: ScrollToZoomEnabledUIAutomation.self, for: .macosScrollToZoomEnabled)
         DefaultsReadUIWriteSettingHandler.register(automation: HoverTextEnabledUIAutomation.self, for: .macosHoverTextEnabled)


### PR DESCRIPTION
I added system-wide (HID) sendKey capabilities to MorphicInput and switched the MorphicBar "Screen Reader" button to "Read Selected" instead.  It now sends Option+Esc to the system/session input key event queue.