### PR TITLE
Add support for macOS 11.0 Big Sur

### DIFF
--- a/Morphic/Morphic.xcodeproj/project.pbxproj
+++ b/Morphic/Morphic.xcodeproj/project.pbxproj
@@ -1133,6 +1133,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MARKETING_VERSION = 0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.raisingthefloor.MorphicConfigurator-Debug";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1155,6 +1156,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MARKETING_VERSION = 0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = org.raisingthefloor.MorphicConfigurator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Morphic Configurator for macOS";

--- a/Morphic/Morphic/AppDelegate.swift
+++ b/Morphic/Morphic/AppDelegate.swift
@@ -48,7 +48,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         populateSolutions()
         createStatusItem()
         loadInitialDefaultPreferences()
-        createEmptyDefaultPreferencesIfNotExist{
+        createEmptyDefaultPreferencesIfNotExist {
             Session.shared.open {
                 os_log(.info, log: logger, "session open")
                 self.logoutItem?.isHidden = Session.shared.user == nil

--- a/Morphic/Morphic/MorphicBar/MorphicBarItem.swift
+++ b/Morphic/Morphic/MorphicBar/MorphicBarItem.swift
@@ -332,7 +332,6 @@ class MorphicBarControlItem: MorphicBarItem{
             }
         }
         
-        
         // make sure the user has "speak selected text..." enabled in System Preferences
         let speakSelectedTextKeyEnabled = defaults.bool(forKey: "SpokenUIUseSpeakingHotKeyFlag")
         if speakSelectedTextKeyEnabled == false {
@@ -373,7 +372,7 @@ class MorphicBarControlItem: MorphicBarItem{
             }
         }else{
             session.storage.load(identifier: "__magnifier__") {
-                (preferences: Preferences?) in
+                (_, preferences: Preferences?) in
                 if let preferences = preferences {
                     let apply = ApplySession(settingsManager: session.settings, preferences: preferences)
                     apply.addFirst(key: .macosZoomEnabled, value: false)

--- a/Morphic/MorphicConfigurator/Info.plist
+++ b/Morphic/MorphicConfigurator/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>FrontEndURL</key>

--- a/MorphicSettings/MorphicSettings/AccessibilityUI/SystemPrefs/AccessibilityPreferencesElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/SystemPrefs/AccessibilityPreferencesElement.swift
@@ -38,7 +38,13 @@ public class AccessibilityPreferencesElement: UIElement {
                 case .display:
                     return "Display"
                 case .speech:
-                    return "Speech"
+                    if ProcessInfo().isOperatingSystemAtLeast(OperatingSystemVersion(majorVersion: 10, minorVersion: 16, patchVersion: 0)) {
+                        // >= macOS 11.0
+                        return "Spoken Content"
+                    } else {
+                        // >= macOS 10.14
+                        return "Speech"
+                    }
                 case .voiceOver:
                     return "VoiceOver"
                 case .zoom:
@@ -74,7 +80,17 @@ public class AccessibilityPreferencesElement: UIElement {
                 completion(false)
                 return
             }
-            self.wait(atMost: 1.0, for: { self.checkbox(titled: "Enable announcements") != nil}) {
+            //
+            let waitForCheckboxTitle: String
+            if ProcessInfo().isOperatingSystemAtLeast(OperatingSystemVersion(majorVersion: 10, minorVersion: 16, patchVersion: 0)) {
+                // >= macOS 11.0
+                waitForCheckboxTitle = "Speak announcements"
+            } else {
+                // >= macOS 10.14
+                waitForCheckboxTitle = "Enable announcements"
+            }
+            //
+            self.wait(atMost: 1.0, for: { self.checkbox(titled: waitForCheckboxTitle) != nil}) {
                 success in
                 completion(success)
             }

--- a/MorphicSettings/MorphicSettings/Automations/SpeechUIAutomations.swift
+++ b/MorphicSettings/MorphicSettings/Automations/SpeechUIAutomations.swift
@@ -62,6 +62,14 @@ public class SpeechCheckboxUIAutomation: AccessibilityUIAutomation {
 
 public class SpeakSelectedTextEnabledUIAutomation: SpeechCheckboxUIAutomation {
 
-    override var checkboxTitle: String! { "Speak selected text when the key is pressed" }
+    override var checkboxTitle: String! {
+        if ProcessInfo().isOperatingSystemAtLeast(OperatingSystemVersion(majorVersion: 10, minorVersion: 16, patchVersion: 0)) {
+            // >= macOS 11.0
+            return "Speak selection"
+        } else {
+            // >= macOS 10.14
+            return "Speak selected text when the key is pressed"
+        }
+    }
 
 }


### PR DESCRIPTION
I made two changes in this release:

macOS 11.0 Big Sur support:
I added version checking to the UI automation for activating the "Speak Selected Text" hotkeys (as both the category tab and checkbox are renamed in macOS 11.0)

Defaults loading/saving:
In some circumstances (permission issues, corrupt files, etc.) the defaults file wasn't getting loaded in macOS and it was causing preferences to be nil (which then caused new preferences to fail to save).  I added some logic which captures the load failure and then added graceful degradation to create an empty set of defaults (which matches the legacy behavior of Morphic on macOS) so that the application can start in a good state.

In the future, we may want to consider more nuance to how we gracefully degrade when the defaults files are missing, locked or corrupt.  Correspondingly we need to think about what we want to do if the preference file cannot be written.  And of course we should think about the user experience around all of the above.

In the meantime, the changes I made are consistent with the existing legacy behavior of Morphic on macOS 10.15, and they give us a bit more error reporting and logging upon which we can build going forward.