### PR TITLE
raise system preferences if minimized

### DIFF
--- a/MorphicSettings/MorphicSettings/AccessibilityUI/ApplicationElement.swift
+++ b/MorphicSettings/MorphicSettings/AccessibilityUI/ApplicationElement.swift
@@ -109,7 +109,7 @@ public class ApplicationElement: UIElement {
         }
     }
     
-    public func terminate() -> Bool{
+    public func terminate() -> Bool {
         guard let runningApplication = runningApplication else {
             return true
         }
@@ -120,7 +120,7 @@ public class ApplicationElement: UIElement {
     }
     
     public var mainWindow: WindowElement? {
-        get{
+        get {
             guard accessibilityElement != nil else {
                 return nil
             }
@@ -128,6 +128,24 @@ public class ApplicationElement: UIElement {
                 return nil
             }
             return WindowElement(accessibilityElement: mainWindow)
+        }
+    }
+    
+    public var windows: [WindowElement]? {
+        get {
+            guard accessibilityElement != nil else {
+                return nil
+            }
+            guard let windows: [MorphicA11yUIElement] = accessibilityElement.values(forAttribute: .windows) else {
+                return nil
+            }
+
+            var windowElements: [WindowElement] = []
+            for window in windows {
+                let windowElement = WindowElement(accessibilityElement: window)
+                windowElements.append(windowElement)
+            }
+            return windowElements
         }
     }
     


### PR DESCRIPTION
JIRA: MOR-254

Morphic cannot navigate System Preferences via UI Automation if System Preferences is minimized.

This bugfix finds the minimized window and raises it so that Morphic's attempt to automation System Preferences's UI succeeds.

Longer-term, I recommend that we add polish which hides the System Preferences window when it is unminimized (as noted in the Jira ticket).