### PR TITLE
VoiceOver Quicknav highlights buttons properly instead of titles

### DIFF
--- a/Morphic/Morphic/MorphicBar/MorphicBarItemView.swift
+++ b/Morphic/Morphic/MorphicBar/MorphicBarItemView.swift
@@ -32,11 +32,6 @@ public class MorphicBarItemView: NSView {
     public override var isFlipped: Bool {
         return true
     }
-    
-    public func getAccessChildren() -> [Any?] {
-        return [nil]
-    }
-    
 }
 
 class MorphicBarSegmentedButtonItemView: MorphicBarItemView {
@@ -54,6 +49,13 @@ class MorphicBarSegmentedButtonItemView: MorphicBarItemView {
         addSubview(titleLabel)
         addSubview(segmentedButton)
         self.needsLayout = true
+
+	// set our accessibility children so that VoiceOver navigates our control properly        
+        var accessibilityChildren: [Any]! = []
+        for button in segmentedButton.segmentButtons {
+            accessibilityChildren.append(button)
+        }
+        setAccessibilityChildren(accessibilityChildren)
     }
     
     override var showsHelp: Bool {
@@ -92,13 +94,4 @@ class MorphicBarSegmentedButtonItemView: MorphicBarItemView {
         // can intercept mouseUp to snap the window to a corner
         return true
     }
-    
-    override func getAccessChildren() -> [Any?] {
-        var reply = [Any]()
-        for button in segmentedButton.segmentButtons {
-            reply.append(button)
-        }
-        return reply
-    }
-    
 }

--- a/Morphic/Morphic/MorphicBar/MorphicBarItemView.swift
+++ b/Morphic/Morphic/MorphicBar/MorphicBarItemView.swift
@@ -33,6 +33,10 @@ public class MorphicBarItemView: NSView {
         return true
     }
     
+    public func getAccessChildren() -> [Any?] {
+        return [nil]
+    }
+    
 }
 
 class MorphicBarSegmentedButtonItemView: MorphicBarItemView {
@@ -87,6 +91,14 @@ class MorphicBarSegmentedButtonItemView: MorphicBarItemView {
         // accept first mouse so the event propagates up to the window and we
         // can intercept mouseUp to snap the window to a corner
         return true
+    }
+    
+    override func getAccessChildren() -> [Any?] {
+        var reply = [Any]()
+        for button in segmentedButton.segmentButtons {
+            reply.append(button)
+        }
+        return reply
     }
     
 }

--- a/Morphic/Morphic/MorphicBar/MorphicBarSegmentedButton.swift
+++ b/Morphic/Morphic/MorphicBar/MorphicBarSegmentedButton.swift
@@ -158,7 +158,7 @@ class MorphicBarSegmentedButton: NSControl {
     // MARK: - Segment Buttons
     
     /// NSButton subclass that provides a custom intrinsic size with content insets
-    private class Button: NSButton {
+    public class Button: NSButton {
         
         private var boundsTrackingArea: NSTrackingArea!
         
@@ -241,7 +241,7 @@ class MorphicBarSegmentedButton: NSControl {
     }
     
     /// The list of buttons corresponding to the segments
-    private var segmentButtons = [Button]()
+    public var segmentButtons = [Button]()
     
     /// Update the segment buttons
     private func updateButtons() {

--- a/Morphic/Morphic/MorphicBar/MorphicBarSegmentedButton.swift
+++ b/Morphic/Morphic/MorphicBar/MorphicBarSegmentedButton.swift
@@ -158,7 +158,7 @@ class MorphicBarSegmentedButton: NSControl {
     // MARK: - Segment Buttons
     
     /// NSButton subclass that provides a custom intrinsic size with content insets
-    public class Button: NSButton {
+    class Button: NSButton {
         
         private var boundsTrackingArea: NSTrackingArea!
         
@@ -241,7 +241,7 @@ class MorphicBarSegmentedButton: NSControl {
     }
     
     /// The list of buttons corresponding to the segments
-    public var segmentButtons = [Button]()
+    var segmentButtons = [Button]()
     
     /// Update the segment buttons
     private func updateButtons() {

--- a/Morphic/Morphic/MorphicBar/MorphicBarViewController.swift
+++ b/Morphic/Morphic/MorphicBar/MorphicBarViewController.swift
@@ -180,6 +180,22 @@ public class MorphicBarViewController: NSViewController {
             }
         }
     }
+    
+    public func getAccessChildren() -> [Any] {
+        var reply = [Any]()
+        for itemView in morphicBarView.itemViews {
+            let children = itemView.getAccessChildren()
+            for child in children {
+                if child != nil {
+                    reply.append(child!)
+                }
+            }
+        }
+        if logoButton != nil {
+            reply.append(logoButton!)
+        }
+        return reply
+    }
 
 }
 

--- a/Morphic/Morphic/MorphicBar/MorphicBarViewController.swift
+++ b/Morphic/Morphic/MorphicBar/MorphicBarViewController.swift
@@ -181,20 +181,20 @@ public class MorphicBarViewController: NSViewController {
         }
     }
     
-    public func getAccessChildren() -> [Any] {
-        var reply = [Any]()
+    // NOTE: we are mirroring the NSView's accessibilityChildren function here to combine and proxy the list to our owner
+    public func accessibilityChildren() -> [Any]? {
+        var result = [Any]()
         for itemView in morphicBarView.itemViews {
-            let children = itemView.getAccessChildren()
-            for child in children {
-                if child != nil {
-                    reply.append(child!)
+            if let children = itemView.accessibilityChildren() {
+                for child in children {
+                    result.append(child)
                 }
             }
         }
-        if logoButton != nil {
-            reply.append(logoButton!)
+        if let logoButton = self.logoButton {
+            result.append(logoButton)
         }
-        return reply
+        return result
     }
 
 }

--- a/Morphic/Morphic/MorphicBar/MorphicBarWindow.swift
+++ b/Morphic/Morphic/MorphicBar/MorphicBarWindow.swift
@@ -66,6 +66,7 @@ public class MorphicBarWindow: NSWindow {
             morphicBarViewController.items = MorphicBarItem.items(from: preferredItems)
         }
         reposition(animated: false)
+        setAccessibilityChildren(morphicBarViewController.getAccessChildren())
     }
     
     public override var canBecomeKey: Bool {

--- a/Morphic/Morphic/MorphicBar/MorphicBarWindow.swift
+++ b/Morphic/Morphic/MorphicBar/MorphicBarWindow.swift
@@ -65,8 +65,9 @@ public class MorphicBarWindow: NSWindow {
         if let preferredItems = Session.shared.array(for: .morphicBarItems) {
             morphicBarViewController.items = MorphicBarItem.items(from: preferredItems)
         }
+        // now that we have updated the items in our bar, update the accessibility children list as well (so that left/right voiceover nav works properly)
+        setAccessibilityChildren(morphicBarViewController.accessibilityChildren())
         reposition(animated: false)
-        setAccessibilityChildren(morphicBarViewController.getAccessChildren())
     }
     
     public override var canBecomeKey: Bool {


### PR DESCRIPTION
Quicknav is the arrow keys navigation for voiceover, it highlights buttons correctly if you tap left and right. On vertical layouts it has odd behavior for up and down, but left and right still go through the order properly. Tab still has a gap between each entry, tried a bunch of things, I have decided not to go further because the odds of accidentally breaking some hooks for other AT in fixing this are pretty high.